### PR TITLE
Add lazy import feature for LLM

### DIFF
--- a/src/llm_search_quality_evaluation/dataset_generator/llm/llm_provider_factory.py
+++ b/src/llm_search_quality_evaluation/dataset_generator/llm/llm_provider_factory.py
@@ -83,7 +83,7 @@ class LLMServiceFactory:
         "openai": build_openai,
         "gemini": build_gemini,
     }
-    _cache: Optional[LazyLLM] = None
+    _cached_lazy_llm: Optional[LazyLLM] = None
 
     @classmethod
     def build(cls, config: LLMConfig) -> BaseChatModel:
@@ -97,10 +97,10 @@ class LLMServiceFactory:
 
     @classmethod
     def build_lazy(cls, config: LLMConfig) -> LazyLLM:
-        if cls._cache is None:
+        if cls._cached_lazy_llm is None:
             log.debug("Creating lazy LLM wrapper for: provider=%s, model=%s", config.name, config.model)
-            cls._cache = LazyLLM(config)
+            cls._cached_lazy_llm = LazyLLM(config)
         else:
             log.debug("Reusing cached lazy LLM wrapper for: provider=%s, model=%s", config.name, config.model)
 
-        return cls._cache
+        return cls._cached_lazy_llm

--- a/src/llm_search_quality_evaluation/dataset_generator/llm/llm_provider_factory.py
+++ b/src/llm_search_quality_evaluation/dataset_generator/llm/llm_provider_factory.py
@@ -83,7 +83,7 @@ class LLMServiceFactory:
         "openai": build_openai,
         "gemini": build_gemini,
     }
-    _cache: dict[str, LazyLLM] = {}
+    _cache: Optional[LazyLLM] = None
 
     @classmethod
     def build(cls, config: LLMConfig) -> BaseChatModel:
@@ -97,12 +97,10 @@ class LLMServiceFactory:
 
     @classmethod
     def build_lazy(cls, config: LLMConfig) -> LazyLLM:
-        cache_key = f"{config.name}:{config.model}"
-
-        if cache_key not in cls._cache:
-            log.debug("Creating lazy LLM wrapper for %s", cache_key)
-            cls._cache[cache_key] = LazyLLM(config)
+        if cls._cache is None:
+            log.debug("Creating lazy LLM wrapper for: provider=%s, model=%s", config.name, config.model)
+            cls._cache = LazyLLM(config)
         else:
-            log.debug("Reusing cached lazy LLM wrapper for %s", cache_key)
+            log.debug("Reusing cached lazy LLM wrapper for: provider=%s, model=%s", config.name, config.model)
 
-        return cls._cache[cache_key]
+        return cls._cache

--- a/src/llm_search_quality_evaluation/dataset_generator/llm/llm_service.py
+++ b/src/llm_search_quality_evaluation/dataset_generator/llm/llm_service.py
@@ -2,10 +2,10 @@ import json
 import logging
 from typing import Optional
 
-from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import HumanMessage, SystemMessage
 from pydantic import BaseModel, ValidationError
 
+from llm_search_quality_evaluation.dataset_generator.llm.llm_provider_factory import LazyLLM
 from llm_search_quality_evaluation.dataset_generator.models.query_response import LLMQueryResponse
 from llm_search_quality_evaluation.dataset_generator.models.score_response import LLMScoreResponse
 from llm_search_quality_evaluation.shared.models.document import Document
@@ -16,7 +16,7 @@ log = logging.getLogger(__name__)
 
 
 class LLMService:
-    def __init__(self, chat_model: BaseChatModel):
+    def __init__(self, chat_model: LazyLLM):
         self.chat_model = chat_model
 
     @staticmethod

--- a/src/llm_search_quality_evaluation/dataset_generator/main.py
+++ b/src/llm_search_quality_evaluation/dataset_generator/main.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 # ------ temporary import for corpus.json bug workaround ------
 import json
 from pathlib import Path
+
+from llm_search_quality_evaluation.dataset_generator.llm.llm_provider_factory import LazyLLM
 from llm_search_quality_evaluation.shared.utils import _to_string
 import argparse
 # -------------------------------------------------------------
 
 from typing import List
-from langchain_core.language_models import BaseChatModel
 from logging import Logger, getLogger
 
 # project imports
@@ -138,7 +139,7 @@ def main() -> None:
         search_engine_type=config.search_engine_type,
         endpoint=config.search_engine_collection_endpoint
     )
-    llm: BaseChatModel = LLMServiceFactory.build(LLMConfig.load(config.llm_configuration_file))
+    llm: LazyLLM = LLMServiceFactory.build_lazy(LLMConfig.load(config.llm_configuration_file))
     service: LLMService = LLMService(chat_model=llm)
     writer: AbstractWriter = WriterFactory.build(writer_config)
 

--- a/tests/llm_search_quality_evaluation/dataset_generator/llm/test_llm_factory.py
+++ b/tests/llm_search_quality_evaluation/dataset_generator/llm/test_llm_factory.py
@@ -1,4 +1,5 @@
 import pytest
+from pydantic_core import ValidationError
 
 from llm_search_quality_evaluation.dataset_generator.llm import LLMConfig, LLMService
 from llm_search_quality_evaluation.dataset_generator.llm.llm_provider_factory import LazyLLM, LLMServiceFactory
@@ -24,13 +25,23 @@ def query():
 
 def test_llm_factory_lazy__expected__llm_none():
     cfg = LLMConfig(
-        name="mock_name",
+        name="openai",
         model="mock_model",
         max_tokens= 1024,
         api_key_env="mock_api_key",
     )
     llm: LazyLLM = LLMServiceFactory.build_lazy(cfg)
     assert llm._llm is None
+
+def test_llm_factory_invalid_model_name__expected__validation_error():
+    with pytest.raises(ValidationError):
+        _ = LLMConfig(
+            name="mock_provider",
+            model="mock_model",
+            max_tokens= 1024,
+            api_key_env="mock_api_key",
+        )
+
 
 
 @pytest.mark.parametrize("provider, model", [

--- a/tests/llm_search_quality_evaluation/dataset_generator/llm/test_llm_factory.py
+++ b/tests/llm_search_quality_evaluation/dataset_generator/llm/test_llm_factory.py
@@ -1,0 +1,51 @@
+import pytest
+
+from llm_search_quality_evaluation.dataset_generator.llm import LLMConfig, LLMService
+from llm_search_quality_evaluation.dataset_generator.llm.llm_provider_factory import LazyLLM, LLMServiceFactory
+from llm_search_quality_evaluation.shared.models import Document
+
+
+@pytest.fixture
+def example_doc():
+    """Provides a sample Document object for testing."""
+    return Document(
+        id="doc1",
+        fields={
+            "title": "Car of the Year",
+            "description": "The Toyota Camry, the nation's most popular car has now been rated as its best new model."
+        }
+    )
+
+
+@pytest.fixture
+def query():
+    return "Is a Toyota the car of the year?"
+
+
+def test_llm_factory_lazy__expected__llm_none():
+    cfg = LLMConfig(
+        name="mock_name",
+        model="mock_model",
+        max_tokens= 1024,
+        api_key_env="mock_api_key",
+    )
+    llm: LazyLLM = LLMServiceFactory.build_lazy(cfg)
+    assert llm._llm is None
+
+
+@pytest.mark.parametrize("provider, model", [
+    ("openai", "gpt-5-nano-2025-08-07"),
+    ("gemini", "gemini-3-pro-preview"),
+])
+def test_llm_factory_lazy_openai__expected__api_key_not_valid(example_doc, query, provider, model):
+    cfg = LLMConfig(
+        name=provider,
+        model=model,
+        max_tokens=1024,
+        api_key_env="invalid_api_key",
+    )
+    llm: LazyLLM = LLMServiceFactory.build_lazy(cfg)
+
+    service: LLMService = LLMService(chat_model=llm)
+    with pytest.raises(ValueError):
+        _ = service.generate_score(example_doc, query, relevance_scale='binary')

--- a/tests/llm_search_quality_evaluation/dataset_generator/test_main_autosave.py
+++ b/tests/llm_search_quality_evaluation/dataset_generator/test_main_autosave.py
@@ -55,7 +55,7 @@ max_tokens: 16
     # Patch factories to avoid network / heavy dependencies
     monkeypatch.setattr(main_mod, "SearchEngineFactory", types.SimpleNamespace(build=lambda **kwargs: object()))
     monkeypatch.setattr(main_mod, "LLMConfig", types.SimpleNamespace(load=lambda _path: object()))
-    monkeypatch.setattr(main_mod, "LLMServiceFactory", types.SimpleNamespace(build=lambda _cfg: object()))
+    monkeypatch.setattr(main_mod, "LLMServiceFactory", types.SimpleNamespace(build_lazy=lambda _cfg: object()))
     monkeypatch.setattr(main_mod, "WriterFactory", types.SimpleNamespace(build=lambda _cfg: DummyWriter()))
 
     # No-op the heavy flow functions to keep the test focused on wiring


### PR DESCRIPTION
Relates to [issue#13](https://github.com/SeaseLtd/llm-search-quality-evaluation/issues/13)

- added lazy import feature for `LLMServiceFactory`: now the Chat Model is initialized at the moment of the first call (so also in the [tutorial repo](https://github.com/SeaseLtd/llm-search-quality-evaluation-tutorial) the API key is not needed)
- added tests to verify the new expected behaviour