### PR TITLE
Allow queries from categories + LLM call batching and multi-threading

### DIFF
--- a/examples/configs/dataset_generator/dataset_generator_config.yaml
+++ b/examples/configs/dataset_generator/dataset_generator_config.yaml
@@ -45,6 +45,51 @@ queries: "examples/queries.txt"
 # Default: true; set to false to disable query generation from documents
 generate_queries_from_documents: true
 
+# (Optional) Generate queries from values of one or more configured fields.
+# Each entry in the list defines:
+#   - fields: array (currently only fields[0] is read); every field must also appear in doc_fields above
+#   - exactly one of:
+#       * values: explicit list of values typed by the user
+#       * values_query_template_file: path to an engine-native facet / aggregation / grouping template.
+#         The engine runs that query at generation time and uses its distinct values for fields[0].
+#         Supported shapes: a Solr request-params JSON dict, an ES/OpenSearch JSON request body, or a
+#         Vespa YQL grouping query. The template's limit (Solr facet.limit / ES-OS terms.size /
+#         Vespa max(N)) is the only knob.
+#   - query_text_template_file: (Optional) path to a plain-text natural-language template whose content
+#     includes the engine's query placeholder ('$query' for Solr/Elasticsearch/OpenSearch, '@kw' for
+#     Vespa — same convention as the engine retrieval query_template above). If omitted, each value is
+#     used directly as the query text (e.g. value "comedy" produces query "comedy").
+# Note: this is a *natural-language* query template (e.g., "$query movies"); it is intentionally distinct
+# from the engine retrieval query_template (Solr params JSON / Vespa YQL / etc.). Pointing this field — or
+# values_query_template_file — at the engine retrieval template is rejected at config load.
+# Budget interaction: if the rendered queries plus other sources exceed num_queries_needed, the surplus is
+# added to the datastore but skipped at scoring time. Duplicate rendered strings dedupe automatically.
+#
+# Explicit values:
+#category_queries:
+#  - fields: ["genres"]
+#    values: ["comedy", "action", "horror", "drama"]
+#    # Bare values: queries are "comedy", "action", "horror", "drama".
+#    # Add `query_text_template_file: "examples/templates/genre_query.tmpl"` (with content like `$query movies`)
+#    # to render wrapped queries instead.
+#
+# Values discovered from the engine (Solr facet, ES/OpenSearch terms agg, or Vespa grouping):
+#   Solr — request-params JSON dict (NOT a Solr JSON Request API body):
+#category_queries:
+#  - fields: ["genres"]
+#    values_query_template_file: "examples/templates/genre_facet_solr.json"
+#    query_text_template_file: "examples/templates/genre_query.tmpl"
+#   Elasticsearch / OpenSearch — full JSON request body. Convention: the aggregation result key
+#   under `aggs` must equal fields[0] (the agg's internal terms.field can be a keyword subfield):
+#category_queries:
+#  - fields: ["genres"]
+#    values_query_template_file: "examples/templates/genre_facet_es.json"
+#   Vespa — YQL only; engine wraps with hits=0 and presentation.format=json.
+#   The grouped field must be an `attribute` in the .sd schema:
+#category_queries:
+#  - fields: ["genres"]
+#    values_query_template_file: "examples/templates/genre_facet_vespa.yql"
+
 # Total number of queries to generate (includes predefined queries, if any)
 num_queries_needed: 30
 
@@ -94,3 +139,53 @@ datastore_autosave_every_n_updates: 50
 # generate the queries.
 # Default: true; the pairs mentioned above are scored.
 enable_cartesian_product: false
+
+# (Optional) Number of (doc) items per LLM relevance-scoring call. Default: 1.
+# 1 = legacy single-pair scoring (one LLM call per (query, doc); equivalent to pre-batching behavior, with one
+# edge case: a provider response of {"score": N, "explanation": ""} is now normalized to explanation=None instead
+# of crashing with ValueError. Shared with the batch path.
+# Set to 2 or more to opt into micro-batching (one LLM call per (query, batch-of-docs)); 10 is a known-good value.
+# NOTE: opting in is a *labeling-behavior* change, not just a transport change. A batch prompt asks the model to
+# score multiple docs in one shared context, which can shift labels for borderline cases compared to per-doc
+# scoring (the model sees siblings and may relativize). Run a small comparison before flipping a production config.
+# Note: enabling `save_llm_explanation` (below) lowers batching ROI because per-doc explanations inflate output
+# length linearly with batch size.
+#llm_micro_batch_size: 10
+
+# (Optional) Per-batch retry budget when llm_micro_batch_size > 1. Default: 3.
+# Any failure (validation error, rate-limit, missing / unknown / duplicate doc_id in the response) triggers a
+# retry with exponential backoff. On exhaustion the run aborts with a non-zero exit; the datastore is still
+# saved on the way out, so a re-run picks up where it stopped.
+#llm_batch_max_retries: 3
+
+# (Optional) Path to a plain-text prompt template for batch relevance scoring.
+# Default: the built-in DEFAULT_BATCH_SCORE_PROMPT, defined in
+# src/llm_search_quality_evaluation/dataset_generator/llm/batch_prompt.py.
+# Required placeholders: {query}, {documents_json}, {relevance_scale}.
+# Optional placeholders: {explanation_instruction}, {rating_scale_description}.
+# Uses Python str.format, so any literal `{` / `}` in the template body (e.g. JSON examples) must be escaped as
+# `{{` / `}}`. The template is validated at config load regardless of llm_micro_batch_size — a broken prompt
+# cannot slip through to runtime. The single-doc prompt (used at llm_micro_batch_size=1) is a separate
+# hard-coded prompt inside LLMService.generate_score and is not configurable; the two flows are decoupled.
+#llm_batch_score_prompt: "examples/templates/batch_score_prompt.txt"
+
+# (Optional) Number of worker threads for parallel LLM calls. Default: 1.
+# Drives two independently-parallelized stages through one knob:
+#   - Query generation from seed documents: one future per seed doc; LLM calls overlap across threads,
+#     results are applied on the main thread in seed-doc order so the stored query set matches the
+#     sequential path exactly.
+#   - Relevance scoring: one future per query in budget; both the cartesian and top-K paths use it.
+# Set to 1 to keep both stages strictly sequential. Increase to overlap network latency on the
+# provider. ROI is primarily wall time: scoring token use matches the sequential path (one call per
+# query within budget), but query generation submits all seed-doc futures before the budget is
+# enforced, so llm_max_workers > 1 can start up to number_of_docs query-generation calls even when
+# num_queries_needed is smaller — increasing query-gen token/API use vs sequential. Combine with
+# llm_micro_batch_size > 1 for fewer scoring requests AND parallel requests.
+#
+# Worker-failure propagation applies to futures whose result is awaited: every scoring future and every
+# query-generation future up to the point num_queries_needed fills. Post-saturation query-gen futures
+# whose results would have been skipped also have their exceptions skipped — they're logged via Python's
+# Future.__del__ path but do not fail the run (the sequential path would not have started those LLM calls
+# either). In-flight and queued *awaited* workers still finish before main() catches the exception and
+# saves the datastore, so progress is durable on disk and a re-run picks up where it stopped.
+#llm_max_workers: 4

--- a/examples/templates/genre_facet_es.json
+++ b/examples/templates/genre_facet_es.json
@@ -1,0 +1,8 @@
+{
+  "size": 0,
+  "aggs": {
+    "genres": {
+      "terms": { "field": "genres.keyword", "size": 100 }
+    }
+  }
+}

--- a/examples/templates/genre_facet_opensearch.json
+++ b/examples/templates/genre_facet_opensearch.json
@@ -1,0 +1,8 @@
+{
+  "size": 0,
+  "aggs": {
+    "genres": {
+      "terms": { "field": "genres.keyword", "size": 100 }
+    }
+  }
+}

--- a/examples/templates/genre_facet_solr.json
+++ b/examples/templates/genre_facet_solr.json
@@ -1,0 +1,7 @@
+{
+  "q": "*:*",
+  "facet": "true",
+  "facet.field": "genres",
+  "facet.limit": 100,
+  "rows": 0
+}

--- a/examples/templates/genre_facet_vespa.yql
+++ b/examples/templates/genre_facet_vespa.yql
@@ -1,0 +1,1 @@
+select * from sources * where true LIMIT 0 | all(group(genres) max(100) each(output(count())))

--- a/examples/templates/genre_query.tmpl
+++ b/examples/templates/genre_query.tmpl
@@ -1,0 +1,1 @@
+$query movies

--- a/src/llm_search_quality_evaluation/dataset_generator/README.md
+++ b/src/llm_search_quality_evaluation/dataset_generator/README.md
@@ -16,6 +16,7 @@ directory (or modify the existing one). This file controls the entire generation
 >     - "solr"
 >     - "elasticsearch"
 >     - "opensearch"
+>     - "vespa"
 > - **collection_name**: Name of the search engine index/collection (e.g., "testcore", the one used in Docker containers)
 > - **search_engine_url**: URL of the search engine (e.g., "http://localhost:8983/solr/")
 > - **documents_filter**: Filter query to restrict the set of documents used to generate queries. If a field has more 
@@ -37,7 +38,89 @@ one fields, the documents are filtered for both fields (AND-like)
 > available, must be in a txt format (e.g., "queries.txt")
 > - **generate_queries_from_documents** (Optional): Whether to generate queries from documents. Default to `true`; set
 > to `false` to disable query generation from documents
-> - **num_queries_needed**: Total number of queries to generate, including predefined queries, if any (e.g., 20)
+> - **category_queries** (Optional): A list of category-derived query sources. Each entry generates queries from the
+> values of one configured field — for example, `genres=[comedy, action, ...]` produces queries like `"comedy"`,
+> `"action"` (or `"comedy movies"`, `"action movies"` if you wrap them via a template). These queries flow through
+> the same `DataStore` as user-supplied and LLM-generated queries, compose with `generate_queries_from_documents`,
+> and use the existing cartesian-product and top-K expansion paths for scoring.
+>
+>   Each entry has:
+>   - **`fields`** — array of field names. Currently only `fields[0]` is read; every field listed must also appear in
+>     `doc_fields` so the LLM scorer has evidence to grade against.
+>   - **Where the values come from** — exactly one of:
+>     - **`values`** — an explicit list typed by the user (e.g. `["comedy", "action"]`).
+>     - **`values_query_template_file`** — a path to an engine-native facet / aggregation / grouping template. The
+>       engine runs that query at generation time and uses its distinct values for `fields[0]`. The template's limit
+>       (Solr `facet.limit`, ES/OS `terms.size`, Vespa grouping `max(N)`) is the only knob.
+>   - **`query_text_template_file`** (Optional) — a plain-text natural-language template wrapping each value. If
+>     omitted, each value is the query text directly (`comedy` → query `"comedy"`). If provided, the file's contents
+>     must contain the engine's query placeholder — `$query` for Solr/Elasticsearch/OpenSearch, `@kw` for Vespa,
+>     matching the same convention as the engine retrieval `query_template` — and each value is substituted into the
+>     placeholder (e.g. `"$query movies"` + `comedy` → `"comedy movies"`).
+>
+>   **Examples — explicit values:**
+>   ```yaml
+>   # Bare values (queries: "comedy", "action", "horror", "drama")
+>   category_queries:
+>     - fields: ["genres"]
+>       values: ["comedy", "action", "horror", "drama"]
+>
+>   # Wrapped via template (queries: "comedy movies", ...) — Solr placeholder
+>   category_queries:
+>     - fields: ["genres"]
+>       values: ["comedy", "action", "horror", "drama"]
+>       query_text_template_file: "examples/templates/genre_query.tmpl"  # contents: $query movies
+>   ```
+>
+>   **Examples — values discovered from the engine.** Replace `values` with `values_query_template_file`. Each engine
+>   reads the template in the same shape it already uses for retrieval, so you don't learn a second convention per
+>   engine:
+>   - **Solr** — the file is a JSON dict of Solr request parameters (`q`, `facet`, `facet.field`, `facet.limit`,
+>     `rows`). The engine injects `wt=json` and GETs `/select` with `params=<the dict>`. Not a Solr JSON Request API
+>     body. Sample: `examples/templates/genre_facet_solr.json`.
+>   - **Elasticsearch / OpenSearch** — the file is a full JSON request body POSTed to `_search`. **Convention:** in the
+>     *request* body the terms aggregation is declared under `aggs` with a name that must equal `fields[0]` (e.g.
+>     `genres` in the shipped samples); Elasticsearch/OpenSearch return buckets under *response* key `aggregations`
+>     with that same name. The agg's internal `terms.field` may be a keyword subfield (`genres.keyword`) without
+>     requiring `genres.keyword` to be in `doc_fields`. Keyed-bucket aggregations (`"keyed": true`) are not supported.
+>     Samples: `examples/templates/genre_facet_es.json`, `examples/templates/genre_facet_opensearch.json`.
+>   - **Vespa** — the file is YQL only; the engine wraps it with `hits=0` and `presentation.format=json` (YQL itself
+>     can't express those). **Precondition:** the grouped field must be declared as an `attribute` in the `.sd`
+>     schema; a non-attribute field will fail at the engine, not at config-load. Sample:
+>     `examples/templates/genre_facet_vespa.yql`.
+>
+>   ```yaml
+>   # Solr
+>   category_queries:
+>     - fields: ["genres"]
+>       values_query_template_file: "examples/templates/genre_facet_solr.json"
+>       query_text_template_file: "examples/templates/genre_query.tmpl"  # optional
+>
+>   # Elasticsearch / OpenSearch
+>   category_queries:
+>     - fields: ["genres"]
+>       values_query_template_file: "examples/templates/genre_facet_es.json"
+>
+>   # Vespa
+>   category_queries:
+>     - fields: ["genres"]
+>       values_query_template_file: "examples/templates/genre_facet_vespa.yql"
+>   ```
+>
+>   Notes: the category templates (natural-language string and value-discovery payload) are both distinct from the
+>   engine retrieval `query_template` (Solr params JSON / Vespa YQL retrieval payload) — pointing either at the engine
+>   retrieval file is rejected at config load, as is pointing `values_query_template_file` at the same path as
+>   `query_text_template_file` on the same source. Discovered values are normalized to non-empty stripped scalar
+>   strings; container-typed bucket keys (nested aggregations) raise rather than landing as nonsense queries. If more
+>   category values are configured (or discovered) than `num_queries_needed`, the surplus is added to the datastore
+>   but skipped at scoring time.
+> - **num_queries_needed**: Total number of queries to generate, including predefined queries, if any (e.g., 20).
+> When the in-memory queries (user-supplied + category + LLM-generated + previously-cached) exceed this number, the
+> selection is prioritized so that fresh sources from this run win over cached entries. Priority order:
+> user-supplied = category > LLM-generated > queries loaded from `resources/tmp/datastore.json`. Within each tier,
+> insertion order is preserved. Practical implication: if your cache already contains `num_queries_needed` queries from
+> a previous run, the fresh user/category queries you add this run still make the cut; previously they were silently
+> dropped because selection used raw insertion order.
 > - **relevance_scale**: Relevance scale used for scoring document relevance
 >   - accepted values: "binary" or "graded", where
 >     - binary: 0 (not relevant), 1 (relevant)
@@ -50,13 +133,96 @@ one fields, the documents are filtered for both fields (AND-like)
 >     - "rre"
 >     - "mteb"
 > - **output_destination**: Path where the output dataset will be saved (e.g., "resources")
-> - **save_llm_explanation**: Whether to save LLM rating score explanation to file. Defaults to `false`
+> - **save_llm_explanation**: Whether to save LLM rating score explanation to file. Defaults to `false`. Note: if
+> the LLM returns a blank or whitespace-only `explanation` (`""`, `" "`, etc.) for an individual rating, it is
+> normalized to "no explanation" rather than aborting the run — `""` is treated the same as the model omitting
+> the field entirely. Both the single-doc and batch flows agree on this normalization.
 > - **llm_explanation_destination** (Needed only if `save_llm_explanation: true`): File path where it contains 
 > <query, doc_id, rating, explanation> records (e.g., "resources/rating_explanation.json")
 > - **datastore_autosave_every_n_updates** (Optional): Number of successful updates (adds or ratings) after which 
 > the in-memory datastore is saved. If not given, the datastore is saved at the end of the process.
 > - **enable_cartesian_product** (Optional): Enable cartesian product scoring between queries and documents used to 
 > generate queries. Defaults to `true`
+> - **llm_micro_batch_size** (Optional): Number of `(doc)` items per LLM relevance-scoring call. Defaults to `1`
+>   (legacy single-pair scoring — one LLM call per `(query, doc)`, equivalent to pre-batching behavior with one
+>   narrow caveat: a provider response of `{"score": N, "explanation": ""}` is now normalized to
+>   `explanation=None` instead of crashing the run with `ValueError`. The change is intentional and is shared
+>   with the batch path, but it means the single-pair path is no longer strictly bit-for-bit with the older code
+>   on that edge case). Set to `2` or more to opt into micro-batching: one LLM call per `(query, batch-of-docs)`,
+>   with a structured list-of-objects response keyed by `doc_id`. A common value is `10`. Applies to **both** the
+>   cartesian and the top-K paths.
+>
+>   **This is a labeling-behavior change, not just a transport change.** A batch prompt asks the model to score
+>   multiple docs in one shared context, which can shift labels for borderline cases compared to per-doc scoring
+>   (the model sees siblings and may relativize). Run a small comparison before flipping a production config.
+>   Also note that enabling `save_llm_explanation` lowers batching ROI because per-doc explanations inflate output
+>   length linearly with batch size.
+> - **llm_batch_max_retries** (Optional): Per-batch retry budget when `llm_micro_batch_size > 1`. Defaults to `3`.
+>   A single uniform rule covers all four failure classes (validation/network/rate-limit error from the provider,
+>   missing `doc_id`, unknown `doc_id`, duplicate `doc_id` in the response): retry the whole batch with
+>   exponential backoff. After `llm_batch_max_retries` additional attempts on top of the initial call, the run
+>   aborts with a `BatchScoringError` and exits non-zero. The datastore is still saved on the way out, so a
+>   re-run picks up where it stopped.
+> - **llm_batch_score_prompt** (Optional): Path to a plain-text prompt template for batch relevance scoring. If
+>   omitted, the built-in default `DEFAULT_BATCH_SCORE_PROMPT` is used — defined in
+>   [src/llm_search_quality_evaluation/dataset_generator/llm/batch_prompt.py](llm/batch_prompt.py).
+>   The template is a Python `str.format` string. Required placeholders: `{query}`, `{documents_json}`,
+>   `{relevance_scale}`. Optional: `{explanation_instruction}`, `{rating_scale_description}`. Any literal
+>   `{` / `}` in the template body (e.g. JSON examples) must be escaped as `{{` / `}}`. **Validation runs at
+>   config load regardless of `llm_micro_batch_size`** — a broken prompt cannot slip through to runtime if you
+>   flip batching on later.
+>
+>   **How the batch prompt differs from the single-doc prompt.** They are intentionally separate code paths,
+>   not two renderings of the same template:
+>   - **Single-doc** (used at `llm_micro_batch_size=1`): hard-coded inside `LLMService.generate_score`. Sends
+>     a `SystemMessage` ("You are a professional data labeler…return the relevance score…in a scale called
+>     BINARY/GRADED") plus a `HumanMessage` containing one document's JSON and the query. The structured
+>     output is a single `{"score": ..., "explanation": ...}` object (`BinaryScore` / `GradedScore`). The
+>     scale values are not spelled out in the prompt; the schema's `Literal[0, 1]` / `Literal[0, 1, 2]`
+>     enforces them.
+>   - **Batch** (used at `llm_micro_batch_size > 1`): rendered from `DEFAULT_BATCH_SCORE_PROMPT` (or your
+>     override). Sends a single `HumanMessage` containing a JSON *array* of documents (`[{"doc_id": ...,
+>     "fields": ...}, ...]`) and the query. The structured output is a `{"ratings": [{"doc_id": ..., "score":
+>     ..., "explanation": ...}, ...]}` list (`BinaryBatchScore` / `GradedBatchScore`). The prompt **spells out
+>     the rating scale verbatim** via `{rating_scale_description}` (e.g. "0 = not relevant, 1 = maybe
+>     relevant, 2 = exact / strong match") so the model sees the meaning of each label rather than relying
+>     on the schema alone, and it instructs the model to include exactly one item per input doc keyed by
+>     `doc_id` so the service can reorder the response without trusting input order.
+>
+>   The single-doc prompt is **not** configurable; only the batch prompt is. The two flows are decoupled by
+>   design: opting into batching is an intentional labeling-behavior change (the model sees siblings and may
+>   relativize), so the prompts evolve independently.
+> - **llm_max_workers** (Optional): Number of worker threads for parallel LLM calls. Defaults to `1`
+>   (strictly sequential). Set to `2` or more to overlap network latency on the LLM provider across:
+>   - **Query generation** from seed documents (one future per seed doc). LLM calls overlap across threads;
+>     results are applied on the **main thread in original seed-doc order** so the stored query set,
+>     dedupe behavior, and `num_queries_needed` cutoff match the sequential path exactly for the same LLM
+>     responses.
+>   - **Relevance scoring** (one future per query in budget). Both the cartesian and top-K paths run through
+>     the same `ThreadPoolExecutor`. Each worker handles all docs for one query — within a query, scoring is
+>     still single-threaded (and still micro-batched when `llm_micro_batch_size > 1`).
+>
+>   **ROI is primarily wall time.** For **scoring**, token usage matches the sequential path — one
+>   call per query already within budget. For **query generation**, however, the wall-time win has a
+>   cost: all seed-doc futures are submitted before the query budget is enforced (see the
+>   worker-failure note below), so with `llm_max_workers > 1` a run can start up to `number_of_docs`
+>   query-generation LLM calls even when `num_queries_needed` is smaller, and any submitted-but-
+>   unawaited future still runs to completion on executor shutdown. Enabling threading can therefore
+>   increase query-generation token/API cost relative to the sequential path. Combine with
+>   `llm_micro_batch_size > 1` for fewer scoring requests AND parallel requests.
+>
+>   **On worker failure** the exception propagates out of the executor *for the futures whose result is
+>   awaited* — that's every scoring future (the `as_completed` loop calls `.result()` on each) and every
+>   query-generation future up to the point the query budget fills. In the query-generation path, once
+>   `num_queries_needed` is reached the loop stops awaiting further futures (those LLM calls were never
+>   "needed" — the sequential path would not have started them either). The executor still waits for those
+>   submitted-but-unawaited workers to finish before `main()` exits, but their exceptions go to the
+>   `Future.__del__` log path rather than propagating. Net effect: scoring failures and pre-saturation
+>   query-gen failures both trigger `main()`'s save-and-reraise; post-saturation query-gen failures are
+>   logged-but-not-fatal. In-flight and queued *awaited* workers still finish before `main()` catches the
+>   exception and saves the datastore, so progress is durable on disk and a re-run picks up where it
+>   stopped. The per-batch retry loop inside `LLMService.generate_scores_batch` is just exercised by more
+>   workers — no extra layer is added on top.
 
 #### Some important things to add
 

--- a/src/llm_search_quality_evaluation/dataset_generator/config.py
+++ b/src/llm_search_quality_evaluation/dataset_generator/config.py
@@ -5,9 +5,73 @@ import logging
 from pathlib import Path
 from urllib.parse import urljoin
 
+from llm_search_quality_evaluation.dataset_generator.llm.batch_prompt import validate_batch_prompt_template
+from llm_search_quality_evaluation.shared.search_engines import SearchEngineFactory
 from llm_search_quality_evaluation.shared.writers import WriterConfig
 
 log = logging.getLogger(__name__)
+
+
+class CategoryQuerySource(BaseModel):
+    fields: List[str] = Field(..., min_length=1,
+                              description="Fields used to derive category values. Only fields[0] is read.")
+    values: Optional[List[str]] = Field(
+        None,
+        min_length=1,
+        description="Explicit list of values used to render category queries. Mutually exclusive with "
+                    "values_query_template_file (set exactly one)."
+    )
+    values_query_template_file: Optional[FilePath] = Field(
+        None,
+        description="Optional path to an engine-native value-discovery template "
+                    "(Solr request-params JSON / ES or OpenSearch JSON request body / Vespa YQL). "
+                    "When set, the engine returns the distinct values for fields[0] at run time. "
+                    "Mutually exclusive with values (set exactly one)."
+    )
+    query_text_template_file: Optional[FilePath] = Field(
+        None,
+        description="Optional path to a plain-text natural-language template. Contents must contain the "
+                    "engine's query placeholder ('@kw' for Vespa, '$query' for Solr/Elasticsearch/OpenSearch). "
+                    "If omitted, each value is used directly as the query text (e.g. 'comedy', 'action')."
+    )
+
+    @field_validator('fields')
+    @classmethod
+    def check_no_empty_fields(cls, value_field: List[str]) -> List[str]:
+        if any(not f.strip() for f in value_field):
+            raise ValueError("category_queries.fields cannot contain empty strings.")
+        return value_field
+
+    @field_validator('values')
+    @classmethod
+    def check_no_empty_values(cls, value_field: Optional[List[str]]) -> Optional[List[str]]:
+        # Field is now Optional so the validator must accept None — Pydantic still routes
+        # None through the field validator on a typed-Optional field.
+        if value_field is None:
+            return value_field
+        if any(not v.strip() for v in value_field):
+            raise ValueError("category_queries.values cannot contain empty strings.")
+        return value_field
+
+    @model_validator(mode="after")
+    def validate_single_field(self) -> "CategoryQuerySource":
+        if len(self.fields) > 1:
+            raise ValueError(
+                "category_queries.fields with more than one entry is not yet supported."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_exactly_one_value_source(self) -> "CategoryQuerySource":
+        """Exactly one of `values` (explicit list) or `values_query_template_file`
+        (engine value-discovery template) must be set."""
+        provided = sum(x is not None for x in (self.values, self.values_query_template_file))
+        if provided != 1:
+            raise ValueError(
+                "category_queries entries must set exactly one of 'values' (explicit list) or "
+                "'values_query_template_file' (engine facet/aggregation/grouping template)."
+            )
+        return self
 
 
 class Config(BaseModel):
@@ -26,7 +90,12 @@ class Config(BaseModel):
     number_of_docs: int = Field(..., gt=0, description="Number of documents to retrieve from the search engine.")
     doc_fields: List[str] = Field(..., min_length=1, description="Fields used for context and scoring.")
     queries: Optional[FilePath] = Field(None, description="Optional file containing predefined queries.")
-    generate_queries_from_documents: Optional[bool] = True
+    generate_queries_from_documents: bool = True
+    category_queries: Optional[List[CategoryQuerySource]] = Field(
+        None,
+        description="Optional list of category-derived query sources. Each source renders queries from "
+                    "values of a configured field through a natural-language template."
+    )
     num_queries_needed: int = Field(..., gt=0, description="Total number of queries to generate.")
     relevance_scale: Literal['binary', 'graded']
     llm_configuration_file: FilePath = Field(..., description="Path to the LLM configuration file.")
@@ -46,6 +115,37 @@ class Config(BaseModel):
     enable_cartesian_product: bool = Field(
         True,
         description="Enable cartesian product scoring between queries and documents used to generate queries."
+    )
+    llm_micro_batch_size: int = Field(
+        1, gt=0,
+        description="Number of (doc) items per LLM relevance-scoring call. "
+                    "1 = single-pair scoring (legacy code path). Set to 2 or "
+                    "more to opt into micro-batching; 10 is a known-good value."
+    )
+    llm_batch_max_retries: int = Field(
+        3, ge=0,
+        description="Per-batch retry budget when llm_micro_batch_size > 1. "
+                    "Any failure (validation error, rate-limit, missing / "
+                    "unknown / duplicate doc_id in the response) triggers a "
+                    "retry with exponential backoff. On exhaustion the run "
+                    "aborts."
+    )
+    llm_batch_score_prompt: Optional[FilePath] = Field(
+        None,
+        description="Optional path to a plain-text prompt template for batch relevance "
+                    "scoring. Must contain '{query}', '{documents_json}', "
+                    "'{relevance_scale}'. If omitted, a built-in default is used. "
+                    "Only used for scoring when llm_micro_batch_size > 1; if "
+                    "provided, it is still validated at config load."
+    )
+    llm_max_workers: int = Field(
+        1, gt=0,
+        description="Number of worker threads for parallel LLM calls: "
+                    "query generation from seed documents (one future per seed doc) "
+                    "and relevance scoring (one future per query in budget). "
+                    "Defaults to 1 (strictly sequential). Increase to overlap "
+                    "network latency on the LLM provider; the throughput win is "
+                    "wall time only — token use is unchanged."
     )
 
     def build_writer_config(self) -> WriterConfig:
@@ -114,11 +214,10 @@ class Config(BaseModel):
     def search_engine_collection_endpoint(self) -> HttpUrl:
         """
         Returns the collection endpoint URL for the search engine.
-        For Vespa: uses vespa_schema instead of collection_name in the endpoint.
+        For Vespa: uses vespa_schema in the endpoint, defaulting to collection_name.
         """
         if self.search_engine_type == "vespa":
-            # For Vespa: use vespa_schema in the endpoint path
-            schema_name = self.vespa_schema or "doc"
+            schema_name = self.vespa_schema or self.collection_name
             return HttpUrl(urljoin(self.search_engine_url.encoded_string() + "/", schema_name + "/"))
         else:
             # For other engines: use collection_name
@@ -135,9 +234,140 @@ class Config(BaseModel):
         return self
 
     @model_validator(mode="after")
-    def check_vespa_fields_required(self) -> "Config":
+    def default_vespa_schema_to_collection_name(self) -> "Config":
         if self.search_engine_type == "vespa" and not self.vespa_schema:
-            raise ValueError("vespa_schema is required when search_engine_type='vespa'")
+            self.vespa_schema = self.collection_name
+        return self
+
+    @model_validator(mode="after")
+    def validate_category_query_fields_in_doc_fields(self) -> "Config":
+        if self.category_queries is None:
+            return self
+        doc_fields_set = set(self.doc_fields)
+        for source in self.category_queries:
+            missing = [f for f in source.fields if f not in doc_fields_set]
+            if missing:
+                raise ValueError(
+                    f"category_queries field(s) {missing} must also be present in doc_fields. "
+                    f"The LLM scorer only sees fields fetched into the Document."
+                )
+        return self
+
+    @property
+    def category_query_placeholder(self) -> str:
+        """Placeholder used inside category-query natural-language templates.
+
+        Reuses the engine class's `QUERY_PLACEHOLDER` so the category template follows the
+        same convention as the engine retrieval template ('$query' for Solr/ES/OpenSearch,
+        '@kw' for Vespa).
+        """
+        return SearchEngineFactory.SEARCH_ENGINE_REGISTRY[self.search_engine_type].QUERY_PLACEHOLDER
+
+    # NOTE on validator ordering: Pydantic runs `model_validator(mode="after")` validators in
+    # declaration order. All path-collision validators must come BEFORE content-reading
+    # validators (e.g. validate_category_query_template_placeholders), so that pointing
+    # `query_text_template_file` at a value-discovery JSON file produces the informative
+    # "different concepts" error rather than a misleading "missing placeholder" one.
+
+    @model_validator(mode="after")
+    def validate_category_template_paths_distinct(self) -> "Config":
+        """Reject path collisions between category-source template files and other templates.
+
+        Three rejected collisions per `CategoryQuerySource`:
+          1. `query_text_template_file` == top-level `query_template` / `rre_query_template`
+             — prevents using the engine retrieval payload as a natural-language template:
+             substitution would dump Solr params JSON / Vespa YQL as the query string.
+          2. `values_query_template_file` == top-level `query_template` / `rre_query_template`
+             — same kind of misuse on the value-discovery side.
+          3. `values_query_template_file` == `query_text_template_file` on the same source
+             — the two fields cohabit on `CategoryQuerySource`, so swapping them is materially
+             more likely than a generic file-path collision.
+        """
+        if self.category_queries is None:
+            return self
+        engine_template_paths = {
+            p.resolve() for p in (self.query_template, self.rre_query_template) if p is not None
+        }
+        for source in self.category_queries:
+            qt_path = source.query_text_template_file.resolve() if source.query_text_template_file else None
+            vq_path = source.values_query_template_file.resolve() if source.values_query_template_file else None
+
+            if qt_path is not None and qt_path in engine_template_paths:
+                raise ValueError(
+                    f"category_queries.query_text_template_file '{source.query_text_template_file}' "
+                    f"points at the same file as the engine retrieval 'query_template' / "
+                    f"'rre_query_template'. These are different concepts: the engine template is the "
+                    f"retrieval payload (e.g. Vespa YQL, Solr params JSON, ES/OS request body); "
+                    f"the category template is a "
+                    f"natural-language query string template like '{self.category_query_placeholder} "
+                    f"movies'. Create a separate plain-text file containing the placeholder "
+                    f"('{self.category_query_placeholder}') and any surrounding wording, and point "
+                    f"'query_text_template_file' at that."
+                )
+
+            if vq_path is not None and vq_path in engine_template_paths:
+                raise ValueError(
+                    f"category_queries.values_query_template_file '{source.values_query_template_file}' "
+                    f"points at the same file as the engine retrieval 'query_template' / "
+                    f"'rre_query_template'. These are different concepts: the engine retrieval "
+                    f"template fetches documents for a given keyword, while the value-discovery "
+                    f"template runs a facet / aggregation / grouping query that returns a list of "
+                    f"distinct values for the configured field."
+                )
+
+            if vq_path is not None and qt_path is not None and vq_path == qt_path:
+                raise ValueError(
+                    f"category_queries.values_query_template_file and category_queries."
+                    f"query_text_template_file on the same source point at the same file "
+                    f"('{source.values_query_template_file}'). These are different concepts: "
+                    f"values_query_template_file is the engine value-discovery payload (Solr "
+                    f"params dict / ES or OpenSearch JSON body / Vespa YQL) that returns the list "
+                    f"of distinct values; query_text_template_file is a plain-text natural-"
+                    f"language template (e.g. '{self.category_query_placeholder} movies') that "
+                    f"wraps each value into a query string."
+                )
+        return self
+
+    @model_validator(mode="after")
+    def validate_batch_score_prompt(self) -> "Config":
+        """Validate the batch-scoring prompt template at config load.
+
+        Validation runs unconditionally when ``llm_batch_score_prompt`` is set —
+        independent of ``llm_micro_batch_size`` — so a broken template can never
+        slip through to runtime if the operator later flips batching on. Uses
+        ``string.Formatter`` so typos (e.g. ``{documents}``) and unescaped JSON
+        braces are caught here, not on the first batch call.
+        """
+        if self.llm_batch_score_prompt is None:
+            return self
+        content = self.llm_batch_score_prompt.read_text(encoding="utf-8")
+        try:
+            validate_batch_prompt_template(content)
+        except ValueError as e:
+            raise ValueError(
+                f"llm_batch_score_prompt '{self.llm_batch_score_prompt}': {e}"
+            ) from e
+        return self
+
+    @model_validator(mode="after")
+    def validate_category_query_template_placeholders(self) -> "Config":
+        if self.category_queries is None:
+            return self
+        placeholder = self.category_query_placeholder
+        for source in self.category_queries:
+            if source.query_text_template_file is None:
+                continue  # bare-value mode: nothing to validate
+            content = source.query_text_template_file.read_text(encoding="utf-8")
+            if placeholder not in content:
+                raise ValueError(
+                    f"query_text_template_file '{source.query_text_template_file}' must contain the "
+                    f"literal placeholder '{placeholder}' (the convention for "
+                    f"search_engine_type='{self.search_engine_type}'). This file is the natural-"
+                    f"language query template used to render category queries (e.g. "
+                    f"'{placeholder} movies'); it is distinct from the engine retrieval template "
+                    f"configured under top-level 'query_template' (Solr params JSON / Vespa YQL / etc.). "
+                    f"Omit this field entirely to use each value as the query text directly."
+                )
         return self
 
     @classmethod

--- a/src/llm_search_quality_evaluation/dataset_generator/llm/__init__.py
+++ b/src/llm_search_quality_evaluation/dataset_generator/llm/__init__.py
@@ -1,9 +1,18 @@
+from llm_search_quality_evaluation.dataset_generator.llm.batch_prompt import (
+    DEFAULT_BATCH_SCORE_PROMPT,
+    load_batch_prompt,
+    validate_batch_prompt_template,
+)
 from llm_search_quality_evaluation.dataset_generator.llm.llm_config import LLMConfig
 from llm_search_quality_evaluation.dataset_generator.llm.llm_provider_factory import LLMServiceFactory
-from llm_search_quality_evaluation.dataset_generator.llm.llm_service import LLMService
+from llm_search_quality_evaluation.dataset_generator.llm.llm_service import BatchScoringError, LLMService
 
 __all__ = [
     "LLMConfig",
     "LLMServiceFactory",
     "LLMService",
+    "BatchScoringError",
+    "DEFAULT_BATCH_SCORE_PROMPT",
+    "load_batch_prompt",
+    "validate_batch_prompt_template",
 ]

--- a/src/llm_search_quality_evaluation/dataset_generator/llm/batch_prompt.py
+++ b/src/llm_search_quality_evaluation/dataset_generator/llm/batch_prompt.py
@@ -1,0 +1,127 @@
+"""Batch relevance-scoring prompt: default template, placeholder contract, validation."""
+from __future__ import annotations
+
+from pathlib import Path
+from string import Formatter
+from typing import Optional, Set
+
+REQUIRED_BATCH_PROMPT_PLACEHOLDERS: frozenset[str] = frozenset({
+    "query",
+    "documents_json",
+    "relevance_scale",
+})
+
+OPTIONAL_BATCH_PROMPT_PLACEHOLDERS: frozenset[str] = frozenset({
+    "explanation_instruction",
+    "rating_scale_description",
+})
+
+ALLOWED_BATCH_PROMPT_PLACEHOLDERS: frozenset[str] = (
+    REQUIRED_BATCH_PROMPT_PLACEHOLDERS | OPTIONAL_BATCH_PROMPT_PLACEHOLDERS
+)
+
+DEFAULT_BATCH_SCORE_PROMPT: str = (
+    "You are a professional data labeler. Given a query and a JSON array of "
+    "documents, return a relevance score for each document on the {relevance_scale} "
+    "scale.\n"
+    "\n"
+    "{rating_scale_description}\n"
+    "\n"
+    'Query: "{query}"\n'
+    "\n"
+    "Documents (JSON array):\n"
+    "{documents_json}\n"
+    "\n"
+    "{explanation_instruction}\n"
+    "\n"
+    'Return a structured object with a "ratings" array. Each item must include '
+    '"doc_id" (matching the input) and "score". Include exactly one item per input '
+    "document, in any order.\n"
+)
+
+
+def validate_batch_prompt_template(template: str) -> None:
+    """Validate a str.format-style batch-scoring prompt template.
+
+    The placeholder grammar is intentionally a *closed* allow-list: each
+    occurrence must be exactly one of the allowed names with no attribute
+    access (``{query.foo}``), item access (``{documents_json[0]}``),
+    conversion (``{query!r}``), or format spec (``{query:{width}}``). The
+    motivation is the fail-early contract: the silent-corruption variants —
+    notably ``{documents_json[0]}`` which renders only the first character of
+    the JSON payload at runtime — are exactly what config-load validation is
+    here to catch.
+
+    Raises ValueError when:
+      - the template cannot be parsed by string.Formatter (e.g. unescaped
+        `{`/`}` in JSON example bodies — the classic str.format footgun);
+      - any field reference is not exactly an allowed placeholder name
+        (covers unknown names, attribute access, and item access);
+      - any field uses a non-empty conversion or format spec;
+      - a required placeholder is missing.
+    """
+    try:
+        parsed = list(Formatter().parse(template))
+    except ValueError as e:
+        raise ValueError(
+            "Batch scoring prompt template could not be parsed by string.Formatter "
+            "(an unescaped '{' or '}' is the usual cause — use '{{' and '}}' to "
+            f"include literal braces): {e}"
+        ) from e
+
+    seen: Set[str] = set()
+    for _literal, field_name, format_spec, conversion in parsed:
+        if field_name is None:
+            continue
+        if field_name == "":
+            raise ValueError(
+                "Batch scoring prompt template uses an unsupported positional "
+                "placeholder '{}'. Use one of the named placeholders: "
+                f"{sorted(ALLOWED_BATCH_PROMPT_PLACEHOLDERS)}."
+            )
+        # Exact match — no attribute access (`{query.x}`) or item access
+        # (`{documents_json[0]}`). `{documents_json[0]}` would silently render
+        # only the first character of the JSON payload at runtime, which is
+        # precisely the silent corruption this validator exists to prevent.
+        if field_name not in ALLOWED_BATCH_PROMPT_PLACEHOLDERS:
+            raise ValueError(
+                f"Batch scoring prompt template references unsupported placeholder "
+                f"'{{{field_name}}}'. Allowed placeholders (exact names, no "
+                f"attribute or item access): "
+                f"{sorted(ALLOWED_BATCH_PROMPT_PLACEHOLDERS)}."
+            )
+        if conversion:
+            raise ValueError(
+                f"Batch scoring prompt template uses an unsupported conversion "
+                f"'!{conversion}' on placeholder '{{{field_name}}}'. Conversions "
+                f"are not part of the closed placeholder grammar."
+            )
+        if format_spec:
+            # Note: a plain `{query}` parses as format_spec='' (falsy), so this
+            # only rejects non-empty specs like `{query:{width}}` or `{query:>10}`.
+            raise ValueError(
+                f"Batch scoring prompt template uses an unsupported format spec "
+                f"':{format_spec}' on placeholder '{{{field_name}}}'. Format "
+                f"specs are not part of the closed placeholder grammar."
+            )
+        seen.add(field_name)
+
+    missing = REQUIRED_BATCH_PROMPT_PLACEHOLDERS - seen
+    if missing:
+        raise ValueError(
+            f"Batch scoring prompt template is missing required placeholder(s) "
+            f"{sorted(missing)}. Required: "
+            f"{sorted(REQUIRED_BATCH_PROMPT_PLACEHOLDERS)}."
+        )
+
+
+def load_batch_prompt(prompt_path: Optional[Path]) -> str:
+    """Return the batch-scoring prompt template body.
+
+    Reads `prompt_path` from disk when set, otherwise returns the built-in
+    default. The service is filesystem-free: this is the single place where
+    "file vs default" is decided.
+    """
+    if prompt_path is None:
+        return DEFAULT_BATCH_SCORE_PROMPT
+    return prompt_path.read_text(encoding="utf-8")

--- a/src/llm_search_quality_evaluation/dataset_generator/llm/llm_provider_factory.py
+++ b/src/llm_search_quality_evaluation/dataset_generator/llm/llm_provider_factory.py
@@ -8,6 +8,7 @@ with lazy initialization for the 2 currently supported LLMs - openai and gemini.
 
 import logging
 import os
+import threading
 from typing import Optional
 
 from dotenv import load_dotenv
@@ -65,13 +66,21 @@ class LazyLLM:
     def __init__(self, config: LLMConfig):
         self.config = config
         self._llm: Optional[BaseChatModel] = None
+        # Guards first-use initialization of `_llm`. The shared LazyLLM is created once in
+        # main() (single-threaded), but its `llm` property can be touched concurrently when
+        # scoring/query-gen run through a ThreadPoolExecutor (llm_max_workers > 1). Without
+        # the lock the first batch of workers can each see `_llm is None` and build the model
+        # redundantly. Double-checked locking keeps the lazy behavior and builds exactly once.
+        self._lock = threading.Lock()
 
     @property
     def llm(self) -> BaseChatModel:
         if self._llm is None:
-            log.info("Initializing LLM for the first time: provider=%s, model=%s",
-                    self.config.name, self.config.model)
-            self._llm = LLMServiceFactory.build(self.config)
+            with self._lock:
+                if self._llm is None:
+                    log.info("Initializing LLM for the first time: provider=%s, model=%s",
+                            self.config.name, self.config.model)
+                    self._llm = LLMServiceFactory.build(self.config)
         return self._llm
 
     def __getattr__(self, name):  # type: ignore[no-untyped-def]

--- a/src/llm_search_quality_evaluation/dataset_generator/llm/llm_service.py
+++ b/src/llm_search_quality_evaluation/dataset_generator/llm/llm_service.py
@@ -1,18 +1,66 @@
 import json
 import logging
-from typing import Optional
+import random
+import time
+from typing import Dict, Iterable, List, Optional
 
 from langchain_core.messages import HumanMessage, SystemMessage
 from pydantic import BaseModel, ValidationError
 
-from llm_search_quality_evaluation.dataset_generator.llm.llm_provider_factory import LazyLLM
 from llm_search_quality_evaluation.dataset_generator.models.query_response import LLMQueryResponse
+from llm_search_quality_evaluation.dataset_generator.llm.llm_provider_factory import LazyLLM
 from llm_search_quality_evaluation.dataset_generator.models.score_response import LLMScoreResponse
 from llm_search_quality_evaluation.shared.models.document import Document
 from llm_search_quality_evaluation.dataset_generator.models.query_schema import create_queries_schema
-from llm_search_quality_evaluation.dataset_generator.models.score_schema import BinaryScore, GradedScore
+from llm_search_quality_evaluation.dataset_generator.models.score_schema import (
+    BinaryBatchScore,
+    BinaryScore,
+    GradedBatchScore,
+    GradedScore,
+)
 
 log = logging.getLogger(__name__)
+
+# Base delay for exponential backoff between batch retries (seconds). The
+# delay for retry attempt `n` (0-indexed) is `_BATCH_RETRY_BASE_SECONDS * 2**n`
+# plus jitter in `[0, _BATCH_RETRY_BASE_SECONDS)`.
+_BATCH_RETRY_BASE_SECONDS: float = 1.0
+
+
+class _BatchResponseContractError(ValueError):
+    """Internal marker for missing / unknown / duplicate doc_id failures.
+
+    Used purely to populate ``BatchScoringError.__cause__`` for response-shape
+    failures so the chained-traceback story is consistent with the
+    invocation-failure path. Not part of the public API — callers always see
+    ``BatchScoringError`` and read its ``reason`` / ``__cause__`` attributes.
+    """
+
+
+class BatchScoringError(RuntimeError):
+    """Raised when a batch scoring call cannot be made clean within retries.
+
+    Carries the query id, the doc ids that were asked for, the batch size, and
+    the number of attempts made — useful for log lines and any future rerun
+    tooling. The underlying cause is chained via ``raise ... from e``.
+    """
+
+    def __init__(
+        self,
+        query_id: str,
+        asked_doc_ids: List[str],
+        attempts: int,
+        reason: str,
+    ):
+        self.query_id = query_id
+        self.asked_doc_ids = list(asked_doc_ids)
+        self.batch_size = len(self.asked_doc_ids)
+        self.attempts = attempts
+        self.reason = reason
+        super().__init__(
+            f"Batch scoring failed for query_id={query_id} after {attempts} "
+            f"attempt(s) on a batch of {self.batch_size} doc(s): {reason}"
+        )
 
 
 class LLMService:
@@ -153,3 +201,141 @@ class LLMService:
             scale=relevance_scale,
             explanation=(model_response.explanation if explanation else None)  # type: ignore[union-attr]
         )
+
+    @staticmethod
+    def _rating_scale_description(relevance_scale: str) -> str:
+        if relevance_scale == "binary":
+            return "Scale: 0 = not relevant, 1 = relevant."
+        return (
+            "Scale: 0 = not relevant, 1 = maybe relevant, 2 = exact / strong match."
+        )
+
+    @staticmethod
+    def _explanation_instruction(explanation: bool) -> str:
+        if explanation:
+            return (
+                "For each item include a clear explanation justifying the score "
+                "in the 'explanation' field."
+            )
+        return "Do not include any explanation."
+
+    @staticmethod
+    def _render_documents_json(documents: Iterable[Document]) -> str:
+        items = [{"doc_id": doc.id, "fields": doc.fields} for doc in documents]
+        return json.dumps(items, ensure_ascii=False)
+
+    def generate_scores_batch(
+        self,
+        query_id: str,
+        query_text: str,
+        documents: List[Document],
+        relevance_scale: str,
+        explanation: bool,
+        prompt_template: str,
+        max_retries: int,
+    ) -> Dict[str, LLMScoreResponse]:
+        """Score multiple docs against a single query in one LLM call.
+
+        On success returns a dict keyed by doc.id with one entry per requested
+        doc. Any of: outright invocation failure (validation error, network /
+        rate-limit error), missing doc_id, unknown doc_id, or duplicate doc_id
+        in the response triggers a whole-batch retry with exponential backoff.
+        After ``max_retries`` additional attempts on top of the initial call
+        the batch is still not clean → raises :class:`BatchScoringError`.
+
+        ``query_id`` is carried for log / error context only; it is *not* sent
+        to the LLM. Only ``query_text`` and the documents go into the prompt.
+        """
+        if relevance_scale not in {"binary", "graded"}:
+            raise ValueError(f"Invalid relevance scale: {relevance_scale}")
+        if not documents:
+            return {}
+
+        schema: type[BaseModel] = (
+            GradedBatchScore if relevance_scale == "graded" else BinaryBatchScore
+        )
+        asked_ids: List[str] = [doc.id for doc in documents]
+        asked_id_set = set(asked_ids)
+        documents_json = self._render_documents_json(documents)
+        rendered_prompt = prompt_template.format(
+            query=query_text,
+            documents_json=documents_json,
+            relevance_scale=relevance_scale,
+            explanation_instruction=self._explanation_instruction(explanation),
+            rating_scale_description=self._rating_scale_description(relevance_scale),
+        )
+        messages = [HumanMessage(content=rendered_prompt)]
+        structured_llm = self.chat_model.with_structured_output(schema)
+
+        last_reason = "no attempts made"
+        # `last_exc` carries the cause for the eventual `raise ... from`.
+        # Invocation failures land here as the real provider exception;
+        # response-contract failures land here as a synthetic
+        # `_BatchResponseContractError` so the final BatchScoringError has a
+        # uniform `__cause__` regardless of failure class — keeps tracebacks
+        # and any tooling that inspects `.__cause__` consistent across the
+        # four conditions in the response-id contract.
+        last_exc: Optional[BaseException] = None
+        total_attempts = max_retries + 1
+        for attempt in range(total_attempts):
+            try:
+                model_response = structured_llm.invoke(messages)
+            except Exception as e:  # ValidationError, network, rate-limit, ...
+                last_exc = e
+                last_reason = f"invocation failure: {type(e).__name__}: {e}"
+                log.warning(
+                    "[generate_scores_batch] %s query_id=%s batch_size=%d attempt=%d/%d",
+                    last_reason, query_id, len(asked_ids), attempt + 1, total_attempts,
+                )
+                if attempt < total_attempts - 1:
+                    self._sleep_backoff(attempt)
+                continue
+
+            returned_ids = [item.doc_id for item in model_response.ratings]  # type: ignore[union-attr]
+            returned_id_set = set(returned_ids)
+
+            if len(returned_ids) != len(returned_id_set):
+                duplicates = sorted(
+                    {rid for rid in returned_ids if returned_ids.count(rid) > 1}
+                )
+                last_reason = f"duplicate doc_id(s) in response: {duplicates}"
+                last_exc = _BatchResponseContractError(last_reason)
+            elif missing := asked_id_set - returned_id_set:
+                last_reason = f"missing doc_id(s) in response: {sorted(missing)}"
+                last_exc = _BatchResponseContractError(last_reason)
+            elif unknown := returned_id_set - asked_id_set:
+                last_reason = f"unknown doc_id(s) in response: {sorted(unknown)}"
+                last_exc = _BatchResponseContractError(last_reason)
+            else:
+                # Clean response: build the result dict.
+                result: Dict[str, LLMScoreResponse] = {}
+                for item in model_response.ratings:  # type: ignore[union-attr]
+                    result[item.doc_id] = LLMScoreResponse(
+                        score=item.score,
+                        scale=relevance_scale,
+                        explanation=(item.explanation if explanation else None),
+                    )
+                return result
+
+            log.warning(
+                "[generate_scores_batch] %s query_id=%s batch_size=%d attempt=%d/%d",
+                last_reason, query_id, len(asked_ids), attempt + 1, total_attempts,
+            )
+            if attempt < total_attempts - 1:
+                self._sleep_backoff(attempt)
+
+        err = BatchScoringError(
+            query_id=query_id,
+            asked_doc_ids=asked_ids,
+            attempts=total_attempts,
+            reason=last_reason,
+        )
+        raise err from last_exc
+
+    @staticmethod
+    def _sleep_backoff(attempt: int) -> None:
+        """Sleep for `base * 2**attempt` seconds plus jitter in `[0, base)`."""
+        delay = _BATCH_RETRY_BASE_SECONDS * (2 ** attempt) + random.uniform(
+            0, _BATCH_RETRY_BASE_SECONDS
+        )
+        time.sleep(delay)

--- a/src/llm_search_quality_evaluation/dataset_generator/main.py
+++ b/src/llm_search_quality_evaluation/dataset_generator/main.py
@@ -3,19 +3,25 @@ from __future__ import annotations
 # ------ temporary import for corpus.json bug workaround ------
 import json
 from pathlib import Path
-
-from llm_search_quality_evaluation.dataset_generator.llm.llm_provider_factory import LazyLLM
 from llm_search_quality_evaluation.shared.utils import _to_string
 import argparse
 # -------------------------------------------------------------
 
-from typing import List
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Callable, List, Tuple
 from logging import Logger, getLogger
 
 # project imports
 from llm_search_quality_evaluation.shared.logger import setup_logging
-from llm_search_quality_evaluation.dataset_generator.llm import LLMConfig, LLMService, LLMServiceFactory
+from llm_search_quality_evaluation.dataset_generator.llm import (
+    LLMConfig,
+    LLMService,
+    LLMServiceFactory,
+    load_batch_prompt,
+)
+from llm_search_quality_evaluation.dataset_generator.llm.llm_provider_factory import LazyLLM
 from llm_search_quality_evaluation.shared.models import Document, Query
+from llm_search_quality_evaluation.shared.models.query import SOURCE_PRIORITY
 from llm_search_quality_evaluation.shared.writers import WriterFactory, AbstractWriter, WriterConfig
 from llm_search_quality_evaluation.shared.search_engines import SearchEngineFactory, BaseSearchEngine
 from llm_search_quality_evaluation.shared.data_store import DataStore
@@ -23,6 +29,7 @@ from llm_search_quality_evaluation.shared.utils import join_fields_as_text
 
 from llm_search_quality_evaluation.dataset_generator.models import LLMQueryResponse, LLMScoreResponse
 from llm_search_quality_evaluation.dataset_generator.config import Config
+from llm_search_quality_evaluation.dataset_generator.query_sources import add_category_queries
 
 log: Logger = getLogger(__name__)
 
@@ -47,13 +54,16 @@ def add_user_queries(config: Config, data_store: DataStore) -> None:
             for line in file:
                 clean_line = line.strip()
                 if clean_line:
-                    data_store.add_query(clean_line)
+                    data_store.add_query(clean_line, source="user")
             log.info(f"Added user-defined queries from file={config.queries}")
 
 
-def generate_and_add_queries(config: Config, data_store: DataStore, llm_service: LLMService,
-                             search_engine: BaseSearchEngine) -> None:
-    """Retrieve docs and generate queries with LLM Service. Adds docs, queries and ratings to the datastore."""
+def fetch_and_add_seed_documents(config: Config, data_store: DataStore,
+                                 search_engine: BaseSearchEngine) -> List[Document]:
+    """Fetch seed documents from the search engine and ensure each is flagged as a cartesian seed.
+
+    Returns the list of fetched documents so callers can reuse them without re-fetching.
+    """
     docs_to_generate_queries: List[Document] = search_engine.fetch_for_query_generation(
         documents_filter=config.documents_filter,
         number_of_docs=config.number_of_docs,
@@ -63,65 +73,249 @@ def generate_and_add_queries(config: Config, data_store: DataStore, llm_service:
     for doc in docs_to_generate_queries:
         doc.is_used_to_generate_queries = True
         data_store.add_document(doc)
+        # Cache hit path: add_document() returned early without updating the stored object.
+        data_store.mark_document_as_query_seed(doc.id)
 
-    remaining = max(0, config.num_queries_needed - len(data_store.get_queries()))
+    return docs_to_generate_queries
+
+
+def generate_and_add_queries_from_documents(config: Config, data_store: DataStore, llm_service: LLMService,
+                                            seed_docs: List[Document]) -> None:
+    """Generate queries with the LLM service from already-fetched seed documents.
+
+    Adds queries and pre-rates each generated query against its source document with the max
+    label from the relevance scale: a query produced from a doc is by definition a perfect match.
+
+    Budget accounting honors the source-priority ordering used by `get_queries_within_budget`:
+    only queries with priority <= 'llm' (i.e. user/category/llm) consume budget slots here.
+    Cached queries do *not* — they're displaceable, so a saturated cache must not block fresh
+    LLM generation.
+
+    At ``config.llm_max_workers > 1`` the per-seed-doc ``generate_queries`` calls are
+    submitted to a ``ThreadPoolExecutor`` so their network latency overlaps. Results are
+    *applied* on the main thread in original ``seed_docs`` order (not ``as_completed``
+    order) so the stored query set and budget cutoff are deterministic and identical to
+    the sequential path for the same LLM responses.
+    """
+    llm_threshold = SOURCE_PRIORITY["llm"]
+
+    def _slots_filled() -> int:
+        return sum(1 for q in data_store.get_queries() if SOURCE_PRIORITY[q.source] <= llm_threshold)
+
+    remaining = max(0, config.num_queries_needed - _slots_filled())
     if remaining == 0:
         return
 
     num_queries_per_doc: int = int((remaining // max(1, config.number_of_docs)) + 1)  # always greater or equal to 1
-    log.debug(f"Number of documents retrieved for generation: {len(docs_to_generate_queries)}")
+    log.debug(f"Number of documents retrieved for generation: {len(seed_docs)}")
     log.debug(f"Pending queries to generate: {remaining}")
     log.debug(f"Number of queries per document: {num_queries_per_doc}")
 
-    for doc in docs_to_generate_queries:
-        query_response: LLMQueryResponse = llm_service.generate_queries(doc, num_queries_per_doc,
-                                                                        config.max_query_terms)
+    def _apply_response(doc: Document, query_response: LLMQueryResponse) -> bool:
+        """Apply a single doc's LLM response. Returns False once the budget is full."""
         for query_ in query_response.get_queries():
-            if len(data_store.get_queries()) >= config.num_queries_needed:
-                return
-            query_obj: Query = data_store.add_query(query_)
+            if _slots_filled() >= config.num_queries_needed:
+                return False
+            query_obj: Query = data_store.add_query(query_, source="llm")
             data_store.create_rating_score(
                 query_obj.id, doc.id, max(config.relevance_label_set),
                 "Default max rating is assigned because the query is generated by the document"
             )
+        return True
+
+    if config.llm_max_workers == 1:
+        for doc in seed_docs:
+            # Re-check between outer iterations so we don't burn an LLM call on doc N+1
+            # after the inner loop on doc N already filled the budget.
+            if _slots_filled() >= config.num_queries_needed:
+                return
+            query_response: LLMQueryResponse = llm_service.generate_queries(
+                doc, num_queries_per_doc, config.max_query_terms
+            )
+            if not _apply_response(doc, query_response):
+                return
+        return
+
+    # Parallel path: submit one future per seed doc up front so network latency
+    # overlaps, but apply results on the main thread in seed-doc order. Iterating
+    # `doc_futures` (not `as_completed`) is deliberate — application order ==
+    # seed order keeps the stored query set, budget cutoff, and dedupe behavior
+    # identical to the sequential loop for the same LLM responses.
+    #
+    # Tradeoff: budget saturation stops *applying* further results, but the
+    # `with ThreadPoolExecutor` block still calls `shutdown(wait=True)` on
+    # return, so any already-submitted futures still run to completion.
+    # That's extra latency/tokens after the budget is full — accepted in
+    # exchange for not adding cancellation machinery.
+    def _gen_queries_for_doc(doc: Document) -> Tuple[Document, LLMQueryResponse]:
+        return doc, llm_service.generate_queries(doc, num_queries_per_doc, config.max_query_terms)
+
+    with ThreadPoolExecutor(max_workers=config.llm_max_workers) as executor:
+        doc_futures = [(doc, executor.submit(_gen_queries_for_doc, doc)) for doc in seed_docs]
+        for doc, fut in doc_futures:
+            # Outer guard: skip applying once the budget is full. We do not
+            # cancel the remaining in-flight futures (see comment above).
+            # Note: futures we return without awaiting do still run to
+            # completion on executor shutdown; if such a worker raises, the
+            # exception is reported via Python's Future.__del__ log path and
+            # is NOT propagated. That's consistent with the sequential path
+            # (which would never have started those LLM calls), but means
+            # post-saturation worker failures are logged-but-not-fatal.
+            if _slots_filled() >= config.num_queries_needed:
+                return
+            _, query_response = fut.result()  # awaited: LLM exceptions propagate
+            if not _apply_response(doc, query_response):
+                return
 
 
-def add_cartesian_product_scores(config: Config, data_store: DataStore, llm_service: LLMService) -> None:
+def get_queries_within_budget(config: Config, data_store: DataStore) -> List[Query]:
+    """Pick the per-run query budget, prioritizing fresh sources over cached ones.
+
+    Stable sort by `(SOURCE_PRIORITY[query.source], insertion_index)` so user/category
+    queries asserted this run always make the cut before queries loaded from the disk
+    cache, while preserving insertion order within each priority tier.
+    """
+    queries = data_store.get_queries()
+    indexed = list(enumerate(queries))
+    indexed.sort(key=lambda iq: (SOURCE_PRIORITY[iq[1].source], iq[0]))
+    queries_within_budget = [q for _, q in indexed[:config.num_queries_needed]]
+    if len(queries) > len(queries_within_budget):
+        log.info(
+            "Processing %s of %s queries due to num_queries_needed=%s",
+            len(queries_within_budget),
+            len(queries),
+            config.num_queries_needed,
+        )
+    return queries_within_budget
+
+
+def score_docs_for_query(
+    config: Config,
+    data_store: DataStore,
+    llm_service: LLMService,
+    prompt_template: str,
+    query: Query,
+    documents: List[Document],
+) -> None:
+    """Score all docs against one query, single-pair or batched per config.
+
+    Filters out already-rated (query, doc) pairs first — same contract as the
+    pre-batching loops. When ``config.llm_micro_batch_size == 1`` the helper
+    routes through the legacy ``generate_score`` (same prompt, same schema,
+    same output as the pre-batching code path — with one narrow caveat: a
+    provider response of ``{"score": N, "explanation": ""}`` is now normalized
+    to ``explanation=None`` instead of raising ``ValueError``; see
+    :class:`LLMScoreResponse`). At 2+ it micro-batches through
+    :meth:`LLMService.generate_scores_batch`.
+
+    Duplicates in ``documents`` are dropped (first occurrence wins). The
+    pre-batching loop was naturally idempotent against duplicates because
+    ``has_rating_score`` was re-checked before *each* single-pair call; this
+    helper snapshots ``pending`` once, so we have to dedupe explicitly. Without
+    this, a duplicate in ``documents`` at ``llm_micro_batch_size > 1`` would
+    send the same id twice to the LLM (whose contract is one item per input
+    doc), trip the duplicate-/missing-id retry rule, and potentially abort the
+    run on what was originally clean input.
+    """
+    pending: List[Document] = []
+    seen_ids: set[str] = set()
+    for d in documents:
+        if d.id in seen_ids:
+            continue
+        if data_store.has_rating_score(query.id, d.id):
+            continue
+        seen_ids.add(d.id)
+        pending.append(d)
+    if not pending:
+        return
+
+    if config.llm_micro_batch_size == 1:
+        for doc in pending:
+            resp: LLMScoreResponse = llm_service.generate_score(
+                doc, query.text, config.relevance_scale, config.save_llm_explanation
+            )
+            data_store.create_rating_score(
+                query.id, doc.id, resp.get_score(),
+                resp.explanation if config.save_llm_explanation else None,
+            )
+        return
+
+    for i in range(0, len(pending), config.llm_micro_batch_size):
+        batch = pending[i : i + config.llm_micro_batch_size]
+        ratings = llm_service.generate_scores_batch(
+            query_id=query.id,
+            query_text=query.text,
+            documents=batch,
+            relevance_scale=config.relevance_scale,
+            explanation=config.save_llm_explanation,
+            prompt_template=prompt_template,
+            max_retries=config.llm_batch_max_retries,
+        )
+        for doc in batch:
+            resp = ratings[doc.id]
+            data_store.create_rating_score(
+                query.id, doc.id, resp.get_score(),
+                resp.explanation if config.save_llm_explanation else None,
+            )
+
+
+def _run_per_query(config: Config, queries: List[Query], work_fn: Callable[[Query], None]) -> None:
+    """Run ``work_fn(query)`` for each query, sequentially or via a worker pool.
+
+    At ``llm_max_workers == 1`` runs strictly sequentially. At ``> 1`` submits
+    one future per query to a ``ThreadPoolExecutor`` and waits on each via
+    ``as_completed`` so any worker exception (``BatchScoringError``,
+    search-engine timeout, plain bug) propagates out to the caller. The
+    enclosing ``with`` block calls ``shutdown(wait=True)`` on the exception
+    path, so in-flight *and queued* workers still finish before the exception
+    reaches ``main()`` and triggers the durability save — this is
+    failure-propagating, not immediate-cancellation.
+    """
+    if config.llm_max_workers == 1:
+        for q in queries:
+            work_fn(q)
+        return
+
+    with ThreadPoolExecutor(max_workers=config.llm_max_workers) as executor:
+        futures = [executor.submit(work_fn, q) for q in queries]
+        for fut in as_completed(futures):
+            fut.result()  # propagates any worker exception
+
+
+def add_cartesian_product_scores(config: Config, data_store: DataStore, llm_service: LLMService,
+                                 prompt_template: str) -> None:
     """Complete the (query, doc) matrix with LLM scores."""
     log.debug("Cartesian product is enabled, so adding cartesian product scores")
-    for query_obj in data_store.get_queries():
-        for doc_obj in data_store.get_cartesian_prod_docs():
-            if not data_store.has_rating_score(query_obj.id, doc_obj.id):
-                score_resp: LLMScoreResponse = llm_service.generate_score(
-                    doc_obj, query_obj.text, config.relevance_scale, config.save_llm_explanation
-                )
-                data_store.create_rating_score(
-                    query_obj.id, doc_obj.id, score_resp.get_score(),
-                    score_resp.explanation if config.save_llm_explanation else None
-                )
+
+    def _work(query_obj: Query) -> None:
+        docs = data_store.get_cartesian_prod_docs()
+        score_docs_for_query(config, data_store, llm_service, prompt_template, query_obj, docs)
+
+    _run_per_query(config, get_queries_within_budget(config, data_store), _work)
 
 
 def expand_docset_with_search_engine_top_k(config: Config, data_store: DataStore,
-                                           llm_service: LLMService, search_engine: BaseSearchEngine) -> None:
+                                           llm_service: LLMService, search_engine: BaseSearchEngine,
+                                           prompt_template: str) -> None:
     """Retrieve docs for each query and score the (q, doc) pairs."""
-    if config.query_template is not None:
-        log.debug(f"Searching for documents with query template in {config.query_template}")
-        for query_obj in data_store.get_queries():
-            docs_eval: List[Document] = search_engine.fetch_for_evaluation(
-                keyword=query_obj.text, query_template=config.query_template, doc_fields=config.doc_fields
-            )
-            for doc_obj in docs_eval:
-                data_store.add_document(doc_obj)
-                if not data_store.has_rating_score(query_obj.id, doc_obj.id):
-                    score_resp: LLMScoreResponse = llm_service.generate_score(
-                        doc_obj, query_obj.text, config.relevance_scale, config.save_llm_explanation
-                    )
-                    data_store.create_rating_score(
-                        query_obj.id, doc_obj.id, score_resp.score,
-                        score_resp.explanation if config.save_llm_explanation else None
-                    )
-    else:
+    if config.query_template is None:
         log.warning("Query template not found. Skipping retrieval.")
+        return
+
+    # Bind the narrowed (non-None) template into a local so the closure below captures a
+    # concrete Path rather than the Optional config attribute.
+    query_template = config.query_template
+    log.debug(f"Searching for documents with query template in {query_template}")
+
+    def _work(query_obj: Query) -> None:
+        docs_eval: List[Document] = search_engine.fetch_for_evaluation(
+            keyword=query_obj.text, query_template=query_template, doc_fields=config.doc_fields
+        )
+        for doc_obj in docs_eval:
+            data_store.add_document(doc_obj)
+        score_docs_for_query(config, data_store, llm_service, prompt_template, query_obj, docs_eval)
+
+    _run_per_query(config, get_queries_within_budget(config, data_store), _work)
 
 
 def main() -> None:
@@ -143,18 +337,51 @@ def main() -> None:
     service: LLMService = LLMService(chat_model=llm)
     writer: AbstractWriter = WriterFactory.build(writer_config)
 
-    # load user queries
-    add_user_queries(config, data_store)
+    # Wrap every datastore-mutating step so any failure (LLM error,
+    # search-engine timeout, plain bug) still leaves whatever was added in
+    # memory durable on disk. The scoping covers query generation (which
+    # adds queries and pre-ratings) and seed-fetch too, not just scoring —
+    # an LLM failure mid-query-gen used to lose the responses that had
+    # already been applied. The inner try/except around save() means a
+    # save failure logs but doesn't mask the original exception (operators
+    # care about the root failure, not the save aftermath).
+    try:
+        # load user queries
+        add_user_queries(config, data_store)
 
-    # generate more queries with LLM service if needed
-    generate_and_add_queries(config, data_store, service, search_engine)
+        # render category-derived queries from each source's explicit values, or from values
+        # discovered by the engine when values_query_template_file is set instead of values.
+        add_category_queries(config, data_store, search_engine)
 
-    # score initial docset
-    if config.enable_cartesian_product:
-        add_cartesian_product_scores(config, data_store, service)
+        # fetch seed documents only when something downstream actually needs them
+        seed_docs: List[Document] = []
+        if config.enable_cartesian_product or config.generate_queries_from_documents:
+            seed_docs = fetch_and_add_seed_documents(config, data_store, search_engine)
 
-    # expand the docset with search engine topK (adding direct ratings)
-    expand_docset_with_search_engine_top_k(config, data_store, service, search_engine)
+        # generate more queries with LLM service from the same seed documents, if enabled
+        if config.generate_queries_from_documents:
+            generate_and_add_queries_from_documents(config, data_store, service, seed_docs)
+
+        # Resolve the batch-scoring prompt template once. Reads `llm_batch_score_prompt`
+        # from disk if set, otherwise returns the built-in default. Always called so
+        # `score_docs_for_query` can pass a concrete string into the LLM service —
+        # the dispatch on `llm_micro_batch_size == 1` ignores the template, but it
+        # costs nothing to resolve it eagerly and keeps the helper signature uniform.
+        batch_prompt_template: str = load_batch_prompt(config.llm_batch_score_prompt)
+
+        # score initial docset
+        if config.enable_cartesian_product:
+            add_cartesian_product_scores(config, data_store, service, batch_prompt_template)
+
+        # expand the docset with search engine topK (adding direct ratings)
+        expand_docset_with_search_engine_top_k(config, data_store, service, search_engine,
+                                               batch_prompt_template)
+    except Exception:
+        try:
+            data_store.save()
+        except Exception:
+            log.exception("Failed to save datastore while handling work-phase failure")
+        raise
 
     # write results
     output_destination = config.output_destination

--- a/src/llm_search_quality_evaluation/dataset_generator/models/__init__.py
+++ b/src/llm_search_quality_evaluation/dataset_generator/models/__init__.py
@@ -1,10 +1,21 @@
 from llm_search_quality_evaluation.dataset_generator.models.query_response import LLMQueryResponse
 from llm_search_quality_evaluation.dataset_generator.models.score_response import LLMScoreResponse
-from llm_search_quality_evaluation.dataset_generator.models.score_schema import BinaryScore, GradedScore
+from llm_search_quality_evaluation.dataset_generator.models.score_schema import (
+    BinaryBatchItem,
+    BinaryBatchScore,
+    BinaryScore,
+    GradedBatchItem,
+    GradedBatchScore,
+    GradedScore,
+)
 
 __all__ = [
     "LLMQueryResponse",
     "LLMScoreResponse",
     "GradedScore",
     "BinaryScore",
+    "BinaryBatchItem",
+    "BinaryBatchScore",
+    "GradedBatchItem",
+    "GradedBatchScore",
 ]

--- a/src/llm_search_quality_evaluation/dataset_generator/models/score_response.py
+++ b/src/llm_search_quality_evaluation/dataset_generator/models/score_response.py
@@ -12,24 +12,32 @@ class LLMScoreResponse:
         Args:
             score:      The relevance score.
             scale:      The relevance scale, either 'binary' {0,1} or 'graded' {0,1,2}.
-            explanation:  Explanation for the generated score or None.
+            explanation:  Explanation for the generated score or None. Blank /
+                whitespace-only strings are normalized to None — providers
+                sometimes return ``""`` instead of omitting the field, and the
+                batch scoring contract already permits per-item explanations to
+                be missing, so treating ``""`` as "missing" is semantically
+                faithful and avoids raising a non-retryable ValueError out of
+                the batch result-assembly path.
 
         Raises:
-            ValueError: If the score is not valid for the given scale.
+            ValueError: If the score is not valid for the given scale or if
+                ``explanation`` is provided and is not a string.
         """
         if scale not in ["binary", "graded"]:
             raise ValueError(f"Invalid scale: {scale}. Must be 'binary' or 'graded'.")
-            
+
         if scale == "binary" and score not in {0, 1}:
             raise ValueError(f"Score must be 0 or 1 for binary scale, got {score}")
         elif scale == "graded" and score not in {0, 1, 2}:
             raise ValueError(f"Score must be 0, 1, or 2 for graded scale, got {score}")
-            
+
         self.score = score
 
-        if explanation is not None:
-            if not isinstance(explanation, str) or not explanation.strip():
-                raise ValueError("`explanation`, if provided, must be a non‑empty string.")
+        if explanation is not None and not isinstance(explanation, str):
+            raise ValueError("`explanation`, if provided, must be a string.")
+        if isinstance(explanation, str) and not explanation.strip():
+            explanation = None
         self.explanation = explanation
 
     def get_score(self) -> int:

--- a/src/llm_search_quality_evaluation/dataset_generator/models/score_schema.py
+++ b/src/llm_search_quality_evaluation/dataset_generator/models/score_schema.py
@@ -1,4 +1,4 @@
-from typing import Optional, Literal
+from typing import List, Optional, Literal
 from pydantic import BaseModel, Field
 
 
@@ -12,3 +12,37 @@ class GradedScore(BaseModel):
     """Returns a graded relevance score."""
     score: Literal[0, 1, 2] = Field(..., description="0 = not relevant, 1 = maybe, 2 = is the answer")
     explanation: Optional[str] = Field(None, description="Explanation for why this score")
+
+
+# Batch schemas — used when `llm_micro_batch_size > 1`. Each *Item carries an
+# explicit `doc_id` because structured-output providers do not guarantee that
+# list-of-objects responses preserve input order; the service keys by `doc_id`
+# rather than by index. See `LLMService.generate_scores_batch` and the
+# response-id contract documented there (every asked id present exactly once,
+# no unasked ids).
+class BinaryBatchItem(BaseModel):
+    """One per-document item in a binary batch relevance-scoring response."""
+    doc_id: str = Field(..., description="Document id as given in the prompt")
+    score: Literal[0, 1] = Field(..., description="0 = not relevant, 1 = relevant")
+    explanation: Optional[str] = Field(None, description="Explanation for why this score")
+
+
+class GradedBatchItem(BaseModel):
+    """One per-document item in a graded batch relevance-scoring response."""
+    doc_id: str = Field(..., description="Document id as given in the prompt")
+    score: Literal[0, 1, 2] = Field(..., description="0 = not relevant, 1 = maybe, 2 = is the answer")
+    explanation: Optional[str] = Field(None, description="Explanation for why this score")
+
+
+class BinaryBatchScore(BaseModel):
+    """Response wrapping per-document binary scores for a single query batch."""
+    ratings: List[BinaryBatchItem] = Field(
+        ..., description="One rating per requested document, keyed by doc_id."
+    )
+
+
+class GradedBatchScore(BaseModel):
+    """Response wrapping per-document graded scores for a single query batch."""
+    ratings: List[GradedBatchItem] = Field(
+        ..., description="One rating per requested document, keyed by doc_id."
+    )

--- a/src/llm_search_quality_evaluation/dataset_generator/query_sources/__init__.py
+++ b/src/llm_search_quality_evaluation/dataset_generator/query_sources/__init__.py
@@ -1,0 +1,3 @@
+from llm_search_quality_evaluation.dataset_generator.query_sources.category_queries import add_category_queries
+
+__all__ = ["add_category_queries"]

--- a/src/llm_search_quality_evaluation/dataset_generator/query_sources/category_queries.py
+++ b/src/llm_search_quality_evaluation/dataset_generator/query_sources/category_queries.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from logging import Logger, getLogger
+from typing import List, Optional
+
+from llm_search_quality_evaluation.dataset_generator.config import Config
+from llm_search_quality_evaluation.shared.data_store import DataStore
+from llm_search_quality_evaluation.shared.search_engines import BaseSearchEngine
+
+log: Logger = getLogger(__name__)
+
+
+def add_category_queries(config: Config, data_store: DataStore,
+                         search_engine: BaseSearchEngine) -> None:
+    """Render category queries from explicit values or engine value-discovery, and add them.
+
+    Explicit-values mode: ``source.values`` is a list typed by the user.
+    Engine-discovery mode: ``source.values_query_template_file`` is set instead, and the
+    engine returns the distinct values for ``source.fields[0]`` at run time.
+
+    Single warning site for empty value-discovery results — engine
+    ``fetch_field_values`` implementations return ``[]`` *silently* when the response path
+    exists but is empty so we don't log the same condition at two layers.
+
+    With a ``query_text_template_file``: each value replaces the engine-appropriate
+    placeholder (``@kw`` for Vespa, ``$query`` for Solr/Elasticsearch/OpenSearch) in the
+    template content. Without one: each value is used directly as the query text.
+    Deduplication is handled by ``DataStore.add_query``.
+    """
+    if not config.category_queries:
+        return
+    placeholder = config.category_query_placeholder
+    for source in config.category_queries:
+        # Explicit-values mode never calls the engine. The if/else is deliberate (rather
+        # than `source.values or engine.fetch_field_values(...)`): a future config knob
+        # that empties `values` mid-pipeline must not silently fall through to an engine
+        # call the user didn't ask for.
+        if source.values is not None:
+            values: List[str] = list(source.values)
+        else:
+            # Config validation guarantees exactly one of values / values_query_template_file
+            # is set, so in this branch the template file is present.
+            assert source.values_query_template_file is not None
+            values = search_engine.fetch_field_values(
+                source.values_query_template_file, source.fields[0]
+            )
+
+        if not values:
+            log.warning(
+                f"[add_category_queries] no values for field='{source.fields[0]}' "
+                f"(template={source.values_query_template_file}); skipping this source"
+            )
+            continue
+
+        template: Optional[str] = (
+            source.query_text_template_file.read_text(encoding="utf-8").strip()
+            if source.query_text_template_file is not None
+            else None
+        )
+        for value in values:
+            query_text = value if template is None else template.replace(placeholder, value)
+            data_store.add_query(query_text, source="category")
+            log.debug(f"[add_category_queries] added query='{query_text}'")

--- a/src/llm_search_quality_evaluation/shared/data_store.py
+++ b/src/llm_search_quality_evaluation/shared/data_store.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
+import threading
 from pathlib import Path
-from typing import Dict, Optional, Tuple, List
+from typing import Any, Dict, Optional, Tuple, List
 
 import json
 import logging
 from uuid import uuid4
 from pydantic import ValidationError
 from llm_search_quality_evaluation.shared.models.document import Document
-from llm_search_quality_evaluation.shared.models.query import Query
+from llm_search_quality_evaluation.shared.models.query import Query, QuerySource, SOURCE_PRIORITY
 from llm_search_quality_evaluation.shared.models.rating import Rating
 from llm_search_quality_evaluation.shared.utils import clean_text
 
@@ -21,12 +22,98 @@ ENCODING = "utf-8"
 class DataStore:
     """In-memory store for documents, queries, and ratings with O(1) indices.
 
-    Invariants:
-    - A (query_id, doc_id) pair is unique within `rating_by_pair`.
-    - `has_rating_score` is True only if a `Rating` object exists for the pair (query_id, document_id).
+    Invariants
+    ----------
+    - A ``(query_id, doc_id)`` pair is unique within ``rating_by_pair``.
+    - ``has_rating_score`` is True only if a ``Rating`` object exists for the
+      pair ``(query_id, doc_id)``.
+
+    Thread safety
+    -------------
+    Public methods are safe to call concurrently. State is protected by a
+    single ``threading.RLock`` (``self._lock``) acquired by every public
+    method that touches the four backing dicts (``docs``, ``queries``,
+    ``rating_by_pair``, ``query_text_to_query_id``) — mutators, bulk getters
+    (the ``list(...values())`` materialization is the snapshot point),
+    existence checks, ``save()``, ``load()``, and
+    ``export_all_records_with_explanation``.
+
+    Why RLock specifically: ``create_rating_score`` would have to re-enter the
+    lock through ``_add_rating`` if the latter took its own lock, and a plain
+    ``Lock`` would deadlock on the second acquisition.
+
+    What is NOT atomic: the ``has_rating_score`` → ``create_rating_score``
+    read-then-act idiom doesn't extend across the two calls. Two workers can
+    both pass ``has_rating_score`` and both call ``create_rating_score``;
+    the second writer is a no-op because ``create_rating_score`` is idempotent
+    on the ``(query_id, doc_id)`` key. The cost is at most one wasted LLM call.
+
+    Autosave pattern (read before adding a new mutator)
+    --------------------------------------------------
+    Mutators that change persistent state follow this shape::
+
+        def add_X(self, ...) -> ...:
+            snapshot: Optional[Dict[str, Any]] = None
+            with self._lock:
+                # ... validate, dedupe, mutate the backing dict ...
+                snapshot = self._capture_autosave_snapshot_if_due()
+            self._persist_autosave(snapshot)
+
+    The split — capture the snapshot under the lock, write it to disk after
+    the lock is released — is what keeps autosave I/O off the worker hot
+    path. Folding ``save()`` back inside the ``with self._lock:`` block (e.g.
+    by calling ``save()`` from a mutator helper) reintroduces the bug where
+    every concurrent worker serializes behind ``tmp_path.write_text()`` /
+    ``tmp_path.replace()``. Don't.
+
+    Private helpers used by the pattern:
+
+    - ``_capture_autosave_snapshot_if_due``: bumps the counter; if the
+      threshold is crossed, builds a JSON-ready snapshot and resets the
+      counter. Caller must hold ``self._lock``.
+    - ``_persist_autosave``: writes a captured snapshot to disk (best-effort,
+      logs on failure). Safe to call without the lock. No-op on ``None``.
+    - ``_add_rating``: returns the snapshot instead of persisting itself, so
+      ``create_rating_score`` can do the persist call after its own lock is
+      released.
+
+    ``load()`` runs the replay through the same mutators but with autosave
+    temporarily suppressed (the threshold is swapped to ``None`` for the
+    duration). Without that suppression, crossing the threshold mid-replay
+    would overwrite the on-disk cache with a partial snapshot.
+
+    Autosave durability limitation
+    ------------------------------
+    Under concurrent autosave, on-disk progress is NOT strictly monotonic.
+    Captures release the lock before the file I/O, so two autosaves race
+    on ``tmp_path.replace()`` — whichever I/O finishes last wins, even if
+    its snapshot was captured earlier. Both snapshots are internally
+    consistent (each was captured under the lock) so the file is never
+    corrupt, but the recovery point can move backwards.
+
+    How far backwards: there is no hard bound. If an early capture's write
+    stalls (slow disk, fsync contention, networked filesystem) while
+    several newer captures complete in the meantime, the stalled write
+    eventually replaces the file with its older snapshot. The practical
+    rollback equals "how many newer captures finished while my write was
+    stalled" — usually zero on a fast local filesystem, potentially more
+    on slower / contended storage.
+
+    The final ``save()`` at end of run is the authoritative state;
+    autosave is a partial-progress convenience, not a contract. If a
+    monotonic guarantee is needed later, the lightest fix is a monotonic
+    ``_autosave_seq`` plus a separate I/O lock that skips writes whose
+    seq is older than the latest persisted (~15 lines).
     """
 
     def __init__(self, path: Path = TMP_FILE, ignore_saved_data: bool = False, autosave_every_n_updates: Optional[int] = None):
+        # ORDER MATTERS: assign self._lock BEFORE calling self.load(). load()
+        # invokes add_document / add_query / _add_rating, each of which
+        # acquires self._lock — moving this line below self.load() makes the
+        # first record loaded raise `AttributeError: 'DataStore' object has
+        # no attribute '_lock'`. Guarded by
+        # test_data_store__load_called_inside_init__lock_already_initialized.
+        self._lock = threading.RLock()
         self.path = path
         # Autosave configuration: when >0, save to disk every N successful mutations
         self._autosave_every_n_updates: Optional[int] = (
@@ -39,10 +126,10 @@ class DataStore:
         self.queries: Dict[str, Query] = {}
 
         # Ratings storage
-        self.rating_by_pair: Dict[Tuple[str, str], Rating] = {}    # (query_id, doc_id) → Rating 
+        self.rating_by_pair: Dict[Tuple[str, str], Rating] = {}    # (query_id, doc_id) → Rating
 
         # Text based deduplication for queries
-        self.query_text_to_query_id: Dict[str, str] = {}           # query_text → query_id 
+        self.query_text_to_query_id: Dict[str, str] = {}           # query_text → query_id
 
         if not ignore_saved_data:
             log.info(f"Loading data from {path}")
@@ -53,42 +140,51 @@ class DataStore:
     # ────────────────────────────────────────────
     def has_document(self, doc_id: str) -> bool:
         """Checks for document existence."""
-        return doc_id in self.docs
+        with self._lock:
+            return doc_id in self.docs
 
     def has_query(self, query_id: str) -> bool:
         """Checks for query existence."""
-        return query_id in self.queries
+        with self._lock:
+            return query_id in self.queries
 
     def has_rating_score(self, query_id: str, doc_id: str) -> bool:
         """Checks for a rating by (query, doc) pair."""
-        return (query_id, doc_id) in self.rating_by_pair
+        with self._lock:
+            return (query_id, doc_id) in self.rating_by_pair
 
     # ────────────────────────────────────────────
     # Getters
     # ────────────────────────────────────────────
     def get_document(self, doc_id: str) -> Optional[Document]:
         """Gets a single document by its ID, or None if not found."""
-        return self.docs.get(doc_id)
+        with self._lock:
+            return self.docs.get(doc_id)
 
     def get_documents(self) -> List[Document]:
         """Gets all documents."""
-        return list(self.docs.values())
+        with self._lock:
+            return list(self.docs.values())
 
     def get_cartesian_prod_docs(self) -> List[Document]:
         """Gets only documents used to generate queries."""
-        return [doc for doc in self.docs.values() if doc.is_used_to_generate_queries]
+        with self._lock:
+            return [doc for doc in self.docs.values() if doc.is_used_to_generate_queries]
 
     def get_query(self, query_id: str) -> Optional[Query]:
         """Gets a single query by its ID, or None if not found."""
-        return self.queries.get(query_id)
+        with self._lock:
+            return self.queries.get(query_id)
 
     def get_queries(self) -> List[Query]:
         """Gets all queries."""
-        return list(self.queries.values())
+        with self._lock:
+            return list(self.queries.values())
 
     def get_ratings(self) -> List[Rating]:
         """Gets all ratings."""
-        return list(self.rating_by_pair.values())
+        with self._lock:
+            return list(self.rating_by_pair.values())
 
 
     # ────────────────────────────────────────────
@@ -96,144 +192,252 @@ class DataStore:
     # ────────────────────────────────────────────
     def add_document(self, doc: Document) -> None:
         """Adds a document."""
-        if self.has_document(doc.id):
-            log.debug(f"[add_document] exists doc_id={doc.id}")
-            return
-        self.docs[doc.id] = doc
-        log.debug(f"[add_document] added doc_id={doc.id}")
-        self._count_update_and_maybe_autosave()
+        snapshot: Optional[Dict[str, Any]] = None
+        with self._lock:
+            if doc.id in self.docs:
+                log.debug(f"[add_document] exists doc_id={doc.id}")
+                return
+            self.docs[doc.id] = doc
+            log.debug(f"[add_document] added doc_id={doc.id}")
+            snapshot = self._capture_autosave_snapshot_if_due()
+        self._persist_autosave(snapshot)
 
-    def add_query(self, query_text_str: str, query_id: Optional[str] = None) -> Query:
-        """Adds a new query. If text is cached, returns existing Query. If id is given, it's used."""
+    def mark_document_as_query_seed(self, doc_id: str) -> None:
+        """Flag an already-stored document as a cartesian seed.
+
+        Required because add_document() returns early when doc_id already
+        exists, so a re-fetched doc cannot update the stored object's
+        is_used_to_generate_queries flag through that path.
+        """
+        snapshot: Optional[Dict[str, Any]] = None
+        with self._lock:
+            doc = self.docs.get(doc_id)
+            if doc is None:
+                log.warning(f"[mark_document_as_query_seed] doc_not_found doc_id={doc_id}")
+                return
+            if not doc.is_used_to_generate_queries:
+                doc.is_used_to_generate_queries = True
+                snapshot = self._capture_autosave_snapshot_if_due()
+        self._persist_autosave(snapshot)
+
+    def add_query(self, query_text_str: str, query_id: Optional[str] = None,
+                  source: Optional[QuerySource] = None) -> Query:
+        """Adds a new query. If text is cached, returns existing Query. If id is given, it's used.
+
+        `source` records how the query was asserted in this run. On a dedup hit the existing
+        query is *promoted* if the incoming source has higher priority than the stored one
+        (cached < llm < user/category) — so re-asserting a previously-cached query as e.g. a
+        user-supplied query updates its label.
+        """
         key = clean_text(query_text_str) # Apply general filtering
-        if existing_id := self.query_text_to_query_id.get(key):
-            log.debug(f"[add_query] exists text='{query_text_str}' key='{key}' existing_id={existing_id}")
-            query = self.queries[existing_id]
-        else:
-            query = Query(id=query_id, text=query_text_str) if query_id else Query(text=query_text_str)
-            self.queries[query.id] = query
-            self.query_text_to_query_id[key] = query.id
-            log.debug(f"[add_query] added query_id={query.id}")
-            self._count_update_and_maybe_autosave()
+        snapshot: Optional[Dict[str, Any]] = None
+        with self._lock:
+            if existing_id := self.query_text_to_query_id.get(key):
+                log.debug(f"[add_query] exists text='{query_text_str}' key='{key}' existing_id={existing_id}")
+                query = self.queries[existing_id]
+                if source is not None and SOURCE_PRIORITY[source] < SOURCE_PRIORITY[query.source]:
+                    log.debug(f"[add_query] promote source {query.source}->{source} for query_id={query.id}")
+                    query.source = source
+            else:
+                kwargs: Dict[str, Any] = {"text": query_text_str}
+                if query_id:
+                    kwargs["id"] = query_id
+                if source is not None:
+                    kwargs["source"] = source
+                query = Query(**kwargs)
+                self.queries[query.id] = query
+                self.query_text_to_query_id[key] = query.id
+                log.debug(f"[add_query] added query_id={query.id} source={query.source}")
+                snapshot = self._capture_autosave_snapshot_if_due()
 
+        self._persist_autosave(snapshot)
         return query
 
-    def _add_rating(self, rating: Rating) -> None:
-        """Adds a rating."""
-        if not self.has_query(rating.query_id):
+    def _add_rating(self, rating: Rating) -> Optional[Dict[str, Any]]:
+        """Add a rating; return an autosave snapshot if one is due.
+
+        Caller must hold ``self._lock`` AND, after releasing it, pass the
+        return value to :meth:`_persist_autosave`. Splitting the snapshot
+        capture from the file I/O is what keeps mutators from serializing
+        worker writes behind disk I/O when the caller's lock is still held.
+        """
+        if rating.query_id not in self.queries:
             log.warning(f"[add_rating] query_not_found query_id={rating.query_id}")
-            return
-        if not self.has_document(rating.doc_id):
+            return None
+        if rating.doc_id not in self.docs:
             log.warning(f"[add_rating] doc_not_found doc_id={rating.doc_id}")
-            return
+            return None
 
         key = (rating.query_id, rating.doc_id)
         if key in self.rating_by_pair:
             log.warning(f"[add_rating] exists q={rating.query_id} d={rating.doc_id}")
-            return
+            return None
 
-        self.rating_by_pair[key] = rating 
+        self.rating_by_pair[key] = rating
         log.debug(f"[add_rating] added q={rating.query_id} d={rating.doc_id}")
-        self._count_update_and_maybe_autosave()
+        return self._capture_autosave_snapshot_if_due()
 
     def create_rating_score(
         self, query_id: str, doc_id: str, score: int, explanation: Optional[str] = None
     ) -> Optional[Rating]:
-        """Create rating (if not exists) and add via `add_rating`."""
+        """Create rating (if not exists) and add via ``_add_rating``.
 
-        key = (query_id, doc_id)
-        if (existing_rating := self.rating_by_pair.get(key)):
-            log.warning(f"[create_rating_score] existing q={query_id} d={doc_id}")
-            return existing_rating
+        The ``rating_by_pair`` check + ``_add_rating`` insert pair runs under
+        the same RLock acquisition so a concurrent caller can't slip in between
+        and double-insert. The autosave file write happens AFTER the lock is
+        released — ``_add_rating`` only captures a snapshot, ``_persist_autosave``
+        writes it.
+        """
+        snapshot: Optional[Dict[str, Any]] = None
+        rating: Optional[Rating] = None
+        with self._lock:
+            key = (query_id, doc_id)
+            if (existing_rating := self.rating_by_pair.get(key)):
+                log.warning(f"[create_rating_score] existing q={query_id} d={doc_id}")
+                return existing_rating
 
-        try:
-            rating = Rating(doc_id=doc_id, query_id=query_id, score=score, explanation=explanation)
-            self._add_rating(rating)
-            return rating
-        except ValidationError as e:
-            log.warning(f"[create_rating_score] validation_failed q={query_id} d={doc_id} score={score} error={e}")
-            return None
+            try:
+                rating = Rating(doc_id=doc_id, query_id=query_id, score=score, explanation=explanation)
+                snapshot = self._add_rating(rating)
+            except ValidationError as e:
+                log.warning(f"[create_rating_score] validation_failed q={query_id} d={doc_id} score={score} error={e}")
+                return None
+
+        self._persist_autosave(snapshot)
+        return rating
 
     # ────────────────────────────────────────────
-    # Autosave helper
+    # Autosave helpers
     # ────────────────────────────────────────────
-    def _count_update_and_maybe_autosave(self) -> None:
-        """Increment mutation counter and autosave if threshold reached.
-        
-        If autosave fails, the counter is not reset to allow retrying on next update.
+    def _capture_autosave_snapshot_if_due(self) -> Optional[Dict[str, Any]]:
+        """Bump the mutation counter; if the autosave threshold is reached,
+        return a JSON-ready snapshot of current state (and reset the counter).
+
+        Caller must hold ``self._lock``. The returned dict is then written
+        to disk OUTSIDE the lock via :meth:`_persist_autosave`. This split
+        is what keeps autosave I/O off the mutator hot path — without it,
+        the outer mutator's ``with self._lock:`` block would serialize
+        worker writes behind ``tmp_path.write_text()`` / ``replace()``.
+
+        The counter is reset *before* the I/O, not after success, so a
+        failed write doesn't pin every subsequent mutation into another
+        autosave attempt. The next autosave runs after the next N mutations
+        regardless.
         """
         if self._autosave_every_n_updates is None:
-            return
-        
+            return None
         self._updates_since_last_save += 1
-        
-        if self._updates_since_last_save >= self._autosave_every_n_updates:
-            try:
-                self.save()
-                log.debug(f"[autosave] ok path={self.path} updates={self._updates_since_last_save}")
-                # OK -> reset counter
-                self._updates_since_last_save = 0  
-            except Exception as e:
-                # Error logged but not raised -> main execution continues without saving
-                log.error(
-                    f"[autosave] failed to save {self.path}."
-                    f"Will retry. Error: {str(e)}",
-                    exc_info=True
-                )
+        if self._updates_since_last_save < self._autosave_every_n_updates:
+            return None
+        self._updates_since_last_save = 0
+        return self._build_snapshot_unlocked()
+
+    def _build_snapshot_unlocked(self) -> Dict[str, Any]:
+        """Materialize a JSON-ready snapshot of the store. Caller must hold ``self._lock``."""
+        return {
+            "docs": [d.model_dump() for d in self.docs.values()],
+            "queries": [q.model_dump() for q in self.queries.values()],
+            "ratings": [r.model_dump() for r in self.rating_by_pair.values()],
+        }
+
+    def _write_snapshot(self, snapshot: Dict[str, Any]) -> None:
+        """Atomically write a snapshot to ``self.path``. Lock-free by design.
+
+        Each write uses a uuid-suffixed tmp path so concurrent autosave
+        writers don't collide on the tmp filename; ``Path.replace()`` is
+        atomic per-FS, so whichever writer finishes last wins — both
+        snapshots are internally consistent (they were captured under the
+        lock) so either is a valid recovery point.
+        """
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = self.path.with_name(self.path.name + f".{uuid4().hex}.tmp")
+        tmp_path.write_text(json.dumps(snapshot, indent=2, ensure_ascii=False), encoding=ENCODING)
+        tmp_path.replace(self.path)
+
+    def _persist_autosave(self, snapshot: Optional[Dict[str, Any]]) -> None:
+        """Best-effort write a captured autosave snapshot. No-op if None.
+
+        Errors are logged, not raised — autosave is a durability convenience,
+        not part of the mutator's contract. The final ``save()`` at end of run
+        still has to succeed for the run to be considered successful.
+        """
+        if snapshot is None:
+            return
+        try:
+            self._write_snapshot(snapshot)
+            log.debug(f"[autosave] ok path={self.path}")
+        except Exception as e:
+            log.error(
+                f"[autosave] failed to save {self.path}. Error: {e}",
+                exc_info=True,
+            )
 
     # ────────────────────────────────────────────
     # Persistence
     # ────────────────────────────────────────────
     def save(self) -> None:
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        data = {
-            "docs": [d.model_dump() for d in self.docs.values()],
-            "queries": [q.model_dump() for q in self.queries.values()],
-            "ratings": [r.model_dump() for r in self.rating_by_pair.values()],
-        }
-        tmp_path = self.path.with_name(self.path.name + f".{uuid4().hex}.tmp")
-        tmp_path.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding=ENCODING)
-        # override previous
-        tmp_path.replace(self.path)
-        
+        """Persist the current state to disk.
+
+        Holds ``self._lock`` only for the dump-to-dict step; file I/O is done
+        outside the lock so workers aren't serialized behind disk writes.
+        """
+        with self._lock:
+            snapshot = self._build_snapshot_unlocked()
+        self._write_snapshot(snapshot)
+
     def load(self) -> None:
-        if not self.path.exists():
-            return
+        """Replay a persisted store from disk.
 
-        # Clear previous data
-        self._clear_all_data()
+        Autosave is suppressed for the duration of the replay: mutators called
+        during load otherwise bump the same counter the user's run uses, and
+        crossing the threshold mid-replay would overwrite the on-disk cache
+        with a partial snapshot. On exit the counter is reset so the user's
+        first real mutation accounts from a clean state.
+        """
+        with self._lock:
+            if not self.path.exists():
+                return
 
-        try:
-            data = json.loads(self.path.read_text(encoding=ENCODING))
-        except json.JSONDecodeError as e:
-            log.warning(f"Could not read datastore {self.path} (JSON). Starting clean. Error: {e}")
-            return
+            # Clear previous data
+            self._clear_all_data()
 
-        # docs
-        for doc_as_dict in data.get("docs", []):
             try:
-                self.add_document(Document.model_validate(doc_as_dict))
-            except ValidationError as e:
-                log.warning(f"[load] skip_doc_invalid data={doc_as_dict} error={e}")
+                data = json.loads(self.path.read_text(encoding=ENCODING))
+            except json.JSONDecodeError as e:
+                log.warning(f"Could not read datastore {self.path} (JSON). Starting clean. Error: {e}")
+                return
 
-        # queries
-        for query_as_dict in data.get("queries", []):
+            saved_threshold = self._autosave_every_n_updates
+            self._autosave_every_n_updates = None
             try:
-                tmp_query = Query.model_validate(query_as_dict)                # Create a new tmp query with loaded dict 
-                self.add_query(query_text_str=tmp_query.text, query_id=tmp_query.id) # Pass (text, ID) values to keep ID consistent
-            except ValidationError as e:
-                log.warning(f"[load] skip_query_invalid data={query_as_dict} error={e}")
+                # docs
+                for doc_as_dict in data.get("docs", []):
+                    try:
+                        self.add_document(Document.model_validate(doc_as_dict))
+                    except ValidationError as e:
+                        log.warning(f"[load] skip_doc_invalid data={doc_as_dict} error={e}")
 
-        # ratings
-        for rating_as_dict in data.get("ratings", []):
-            try:
-                robj = Rating.model_validate(rating_as_dict)
-                self._add_rating(robj)
-            except ValidationError as e:
-                log.warning(f"[load] skip_rating_invalid data={rating_as_dict} error={e}")
+                # queries
+                for query_as_dict in data.get("queries", []):
+                    try:
+                        tmp_query = Query.model_validate(query_as_dict)                # Create a new tmp query with loaded dict
+                        self.add_query(query_text_str=tmp_query.text, query_id=tmp_query.id) # Pass (text, ID) values to keep ID consistent
+                    except ValidationError as e:
+                        log.warning(f"[load] skip_query_invalid data={query_as_dict} error={e}")
+
+                # ratings
+                for rating_as_dict in data.get("ratings", []):
+                    try:
+                        robj = Rating.model_validate(rating_as_dict)
+                        self._add_rating(robj)
+                    except ValidationError as e:
+                        log.warning(f"[load] skip_rating_invalid data={rating_as_dict} error={e}")
+            finally:
+                self._autosave_every_n_updates = saved_threshold
+                self._updates_since_last_save = 0
 
     def _clear_all_data(self) -> None:
-        """Reset state."""
+        """Reset state. Caller must hold ``self._lock``."""
         self.docs.clear()
         self.queries.clear()
         self.rating_by_pair.clear()
@@ -242,18 +446,19 @@ class DataStore:
 
     def export_all_records_with_explanation(self, output_path: str | Path) -> None:
         """Export (query_text, doc_id, rating, explanation) to JSON."""
-        records = []
-        for rating_obj in self.rating_by_pair.values():
-            # Guard against dangling references (defensive)
-            query_obj = self.queries.get(rating_obj.query_id)
-            if not query_obj:
-                continue
-            records.append({
-                "query": query_obj.text,
-                "doc_id": rating_obj.doc_id,
-                "rating": rating_obj.score,
-                "explanation": rating_obj.explanation or ""
-            })
+        with self._lock:
+            records = []
+            for rating_obj in self.rating_by_pair.values():
+                # Guard against dangling references (defensive)
+                query_obj = self.queries.get(rating_obj.query_id)
+                if not query_obj:
+                    continue
+                records.append({
+                    "query": query_obj.text,
+                    "doc_id": rating_obj.doc_id,
+                    "rating": rating_obj.score,
+                    "explanation": rating_obj.explanation or ""
+                })
 
         output_path = Path(output_path)
         output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/llm_search_quality_evaluation/shared/models/query.py
+++ b/src/llm_search_quality_evaluation/shared/models/query.py
@@ -1,6 +1,23 @@
 from __future__ import annotations
+from typing import Dict, Literal
 from uuid import uuid4
 from pydantic import BaseModel, Field, ConfigDict
+
+# Provenance label used to prioritize which queries make it into the per-run budget.
+# It's a *runtime* label that reflects how the query was asserted in the current run, not
+# a property of the persisted data. The datastore JSON cache must not include it: anything
+# loaded from disk should be treated as 'cached' until promoted by a fresh add this run.
+QuerySource = Literal["user", "category", "llm", "cached"]
+
+# Lower number = higher priority for budgeting. user/category share priority 0 because
+# both represent explicit user intent for this run; llm-generated comes next; cached last.
+SOURCE_PRIORITY: Dict[str, int] = {
+    "user": 0,
+    "category": 0,
+    "llm": 1,
+    "cached": 2,
+}
+
 
 class Query(BaseModel):
     """
@@ -17,3 +34,6 @@ class Query(BaseModel):
 
     id: str = Field(default_factory=lambda: str(uuid4()), description="Unique identifier of the query.", min_length=1)
     text: str = Field(..., description="The raw query text.", min_length=1)
+    # Excluded from model_dump so it's never written to the datastore JSON cache;
+    # on load every query falls back to the default 'cached' label.
+    source: QuerySource = Field(default="cached", exclude=True)

--- a/src/llm_search_quality_evaluation/shared/search_engines/elasticsearch_search_engine.py
+++ b/src/llm_search_quality_evaluation/shared/search_engines/elasticsearch_search_engine.py
@@ -9,6 +9,9 @@ from typing import List, Dict, Any, Union, Optional
 
 from llm_search_quality_evaluation.shared.search_engines.search_engine_base import BaseSearchEngine
 from llm_search_quality_evaluation.shared.models.document import Document
+from llm_search_quality_evaluation.shared.search_engines.es_opensearch_terms_agg_values import (
+    list_values_from_terms_aggregations,
+)
 from llm_search_quality_evaluation.shared.utils import clean_text
 
 import logging
@@ -117,6 +120,30 @@ class ElasticsearchSearchEngine(BaseSearchEngine):
         fields = doc_fields if self.UNIQUE_KEY in doc_fields else doc_fields + [self.UNIQUE_KEY]
         payload["_source"] = fields
         return self._search(payload)
+
+    def fetch_field_values(self, values_query_template: Path | str, field: str) -> List[str]:
+        """Run an ES aggregation payload (full JSON request body) and return distinct values.
+
+        Convention: the aggregation result key under ``aggregations`` must equal ``field``.
+        This is about the *result key in the JSON tree*, not the aggregation's internal
+        ``terms.field`` parameter — users routinely aggregate on ``genres.keyword`` while
+        naming the agg ``genres``, which is supported.
+
+        Keyed-bucket form (``"keyed": true`` → ``buckets`` is a dict) is unsupported.
+        """
+        payload: Dict[str, Any] = self._parse_query_template(values_query_template)
+        search_url = urljoin(self.endpoint.encoded_string(), '_search')
+
+        log.debug(f"[fetch_field_values] Elasticsearch POST {search_url} payload={str(payload)[:500]}")
+
+        try:
+            response = requests.post(search_url, headers=self.HEADERS, json=payload)
+            response.raise_for_status()
+        except (ConnectionError, Timeout, RequestException, HTTPError) as e:
+            log.error(f"Elasticsearch value-discovery query failed: {e}")
+            raise
+
+        return list_values_from_terms_aggregations(response.json().get("aggregations", {}), field)
 
     def _search(self, payload: Dict[str, Any]) -> List[Document]:
         """

--- a/src/llm_search_quality_evaluation/shared/search_engines/es_opensearch_terms_agg_values.py
+++ b/src/llm_search_quality_evaluation/shared/search_engines/es_opensearch_terms_agg_values.py
@@ -1,0 +1,33 @@
+"""Parse Elasticsearch/OpenSearch `_search` terms-aggregation responses for value discovery."""
+
+from __future__ import annotations
+
+from typing import Any, List
+
+from llm_search_quality_evaluation.shared.utils import normalize_discovered_field_values
+
+
+def list_values_from_terms_aggregations(aggregations: Any, field: str) -> List[str]:
+    """Return normalized distinct values from ``aggregations[field].buckets[*].key``.
+
+    Convention: the aggregation result key under the response's ``aggregations`` object must
+    equal ``field`` (the request body still uses ``aggs``). Keyed-bucket form
+    (``\"keyed\": true``) is unsupported.
+    """
+    if not isinstance(aggregations, dict):
+        aggregations = {}
+    agg_entry = aggregations.get(field)
+    if not isinstance(agg_entry, dict) or "buckets" not in agg_entry:
+        raise ValueError(
+            f"ES/OS value-discovery: expected aggregations.{field}.buckets in response. "
+            f"Convention: the aggregation result key must equal fields[0] ('{field}'); "
+            f"the aggregation's internal terms.field can be a keyword subfield "
+            f"(e.g. '{field}.keyword') without affecting this convention."
+        )
+    buckets = agg_entry["buckets"]
+    if not isinstance(buckets, list):
+        raise ValueError(
+            f"ES/OS value-discovery: aggregations.{field}.buckets must be a list. "
+            f"Keyed-bucket aggregations (`'keyed': true`) are not supported."
+        )
+    return normalize_discovered_field_values(b.get("key") for b in buckets)

--- a/src/llm_search_quality_evaluation/shared/search_engines/opensearch_engine.py
+++ b/src/llm_search_quality_evaluation/shared/search_engines/opensearch_engine.py
@@ -9,6 +9,9 @@ from requests.exceptions import HTTPError, ConnectionError, Timeout, RequestExce
 
 from llm_search_quality_evaluation.shared.models.document import Document
 from llm_search_quality_evaluation.shared.search_engines.search_engine_base import BaseSearchEngine
+from llm_search_quality_evaluation.shared.search_engines.es_opensearch_terms_agg_values import (
+    list_values_from_terms_aggregations,
+)
 from llm_search_quality_evaluation.shared.utils import clean_text
 
 log = logging.getLogger(__name__)
@@ -95,6 +98,28 @@ class OpenSearchEngine(BaseSearchEngine):
         payload["_source"] = fields
 
         return self._search(payload)
+
+    def fetch_field_values(self, values_query_template: Path | str, field: str) -> List[str]:
+        """Run an OpenSearch aggregation payload (full JSON request body) and return distinct values.
+
+        Convention mirrors Elasticsearch: the aggregation result key under ``aggregations`` must
+        equal ``field`` (the agg's internal ``terms.field`` may be a keyword subfield).
+
+        Keyed-bucket form (``"keyed": true`` → ``buckets`` is a dict) is unsupported.
+        """
+        payload: Dict[str, Any] = self._parse_query_template(values_query_template)
+        search_url = f"{self.endpoint}/_search"
+
+        log.debug(f"[fetch_field_values] OpenSearch POST {search_url} payload={str(payload)[:500]}")
+
+        try:
+            response = requests.post(search_url, headers=self.HEADERS, json=payload)
+            response.raise_for_status()
+        except (ConnectionError, Timeout, RequestException, HTTPError) as e:
+            log.error(f"OpenSearch value-discovery query failed: {e}")
+            raise
+
+        return list_values_from_terms_aggregations(response.json().get("aggregations", {}), field)
 
     def _search(self, payload: Dict[str, Any]) -> List[Document]:
         """Perform a search to OpenSearch and return matching documents based on the given payload."""

--- a/src/llm_search_quality_evaluation/shared/search_engines/search_engine_base.py
+++ b/src/llm_search_quality_evaluation/shared/search_engines/search_engine_base.py
@@ -14,9 +14,12 @@ class BaseSearchEngine(ABC):
          '{', '}', '~', '*', '?', '|', '&', '/'}
     SPECIAL_CHARS: set[str] = s
 
+    # Engine-specific placeholder convention used in query templates. Subclasses override
+    # when their engine uses a different convention (e.g. Vespa uses YQL '@kw').
+    QUERY_PLACEHOLDER: str = "$query"
+
     def __init__(self, endpoint: HttpUrl):
         self.endpoint = HttpUrl(endpoint)
-        self.QUERY_PLACEHOLDER = "$query"
         self.UNIQUE_KEY = 'id'
 
     @staticmethod
@@ -101,6 +104,38 @@ class BaseSearchEngine(ABC):
                              keyword: str="*:*") \
             -> List[Document]:
         """Search for documents based on a keyword and a query template to evaluate the system."""
+        pass
+
+    @abstractmethod
+    def fetch_field_values(self, values_query_template: Path | str, field: str) -> List[str]:
+        """Run an engine-native facet/aggregation/grouping payload and return the distinct values
+        produced for ``field``.
+
+        Per-engine transport (deliberately different so each engine matches its existing
+        retrieval convention):
+
+        - **Solr** — the template is a JSON dict of Solr request *parameters* (``q``, ``facet``,
+          ``facet.field``, ``facet.limit``, ``rows``, ...). Parsed with ``_parse_query_template``,
+          ``wt=json`` is injected, and the call is ``GET /select?<params>`` (NOT a Solr JSON
+          Request API body).
+        - **Elasticsearch / OpenSearch** — the template is the full JSON request body, POSTed
+          to ``_search`` unchanged.
+        - **Vespa** — the template is YQL only; the implementation wraps it with
+          ``{"yql": <file>, "hits": 0, "presentation.format": "json"}`` and POSTs.
+
+        The template's limit (Solr ``facet.limit``, ES/OS terms ``size``, Vespa grouping
+        ``max(N)``) is the only knob — there is no separate config option.
+
+        Return values are normalized to non-empty stripped strings via
+        ``shared.utils.normalize_discovered_field_values`` (containers raise).
+
+        Empty result (response path exists but contains zero buckets/values) → return ``[]``
+        *silently*. The single warning lives in ``add_category_queries`` so it carries full
+        source context (``field``, ``values_query_template_file``).
+
+        Missing/wrong-typed/wrong-key response path → raise ``ValueError`` with engine context.
+        HTTP/JSON parse errors propagate or are wrapped with engine context.
+        """
         pass
 
     @abstractmethod

--- a/src/llm_search_quality_evaluation/shared/search_engines/search_engine_factory.py
+++ b/src/llm_search_quality_evaluation/shared/search_engines/search_engine_factory.py
@@ -5,6 +5,7 @@ from llm_search_quality_evaluation.shared.search_engines.opensearch_engine impor
 from llm_search_quality_evaluation.shared.search_engines.search_engine_base import BaseSearchEngine
 from llm_search_quality_evaluation.shared.search_engines.solr_search_engine import SolrSearchEngine
 from llm_search_quality_evaluation.shared.search_engines.elasticsearch_search_engine import ElasticsearchSearchEngine
+from llm_search_quality_evaluation.shared.search_engines.vespa_search_engine import VespaSearchEngine
 
 import logging
 
@@ -15,7 +16,8 @@ class SearchEngineFactory:
     SEARCH_ENGINE_REGISTRY: Dict[str, Type[BaseSearchEngine]] = {
         "solr": SolrSearchEngine,
         "opensearch": OpenSearchEngine,
-        "elasticsearch": ElasticsearchSearchEngine
+        "elasticsearch": ElasticsearchSearchEngine,
+        "vespa": VespaSearchEngine,
     }
 
     @classmethod

--- a/src/llm_search_quality_evaluation/shared/search_engines/solr_search_engine.py
+++ b/src/llm_search_quality_evaluation/shared/search_engines/solr_search_engine.py
@@ -7,7 +7,7 @@ from typing import List, Dict, Any, Union
 
 from llm_search_quality_evaluation.shared.search_engines.search_engine_base import BaseSearchEngine
 from llm_search_quality_evaluation.shared.models.document import Document
-from llm_search_quality_evaluation.shared.utils import clean_text
+from llm_search_quality_evaluation.shared.utils import clean_text, normalize_discovered_field_values
 
 import logging
 import json
@@ -114,6 +114,46 @@ class SolrSearchEngine(BaseSearchEngine):
         payload['fl'] = self._unify_fields(doc_fields)
 
         return self._search(payload)
+
+    def fetch_field_values(self, values_query_template: Path | str, field: str) -> List[str]:
+        """Run a Solr facet payload (request-params dict) and return distinct values for ``field``.
+
+        The template is a flat JSON dict of Solr request parameters. ``wt=json`` is injected
+        the same way ``_search`` does, and the request goes out as ``GET /select?<params>``.
+        Response navigation: ``facet_counts.facet_fields.<field>`` is a flat alternating
+        ``[v0, c0, v1, c1, ...]`` array; we drop counts and keep the values.
+        """
+        payload: Dict[str, Any] = self._parse_query_template(values_query_template)
+        payload['wt'] = 'json'
+        search_url = urljoin(self.endpoint.encoded_string(), 'select')
+
+        log.debug(f"[fetch_field_values] Solr GET {search_url} params={str(payload)[:500]}")
+
+        try:
+            response = requests.get(search_url, headers=self.HEADERS, params=payload)
+            response.raise_for_status()
+        except (ConnectionError, Timeout, RequestException, HTTPError) as e:
+            log.error(f"Solr value-discovery query failed: {e}")
+            raise
+
+        body = response.json()
+        fc = body.get("facet_counts")
+        if fc is None or "facet_fields" not in fc or field not in fc["facet_fields"]:
+            raise ValueError(
+                f"Solr value-discovery: expected facet_counts.facet_fields.{field} in response."
+            )
+        arr = fc["facet_fields"][field]
+        if not isinstance(arr, list):
+            raise ValueError(
+                f"Solr value-discovery: facet_counts.facet_fields.{field} must be a list, "
+                f"got {type(arr).__name__}."
+            )
+        if len(arr) % 2 != 0:
+            raise ValueError(
+                f"Solr value-discovery: facet_counts.facet_fields.{field} must have even length "
+                f"(alternating value/count), got len={len(arr)}."
+            )
+        return normalize_discovered_field_values(arr[i] for i in range(0, len(arr), 2))
 
     def _search(self, payload: Dict[str, Any]) -> List[Document]:
         """

--- a/src/llm_search_quality_evaluation/shared/search_engines/vespa_search_engine.py
+++ b/src/llm_search_quality_evaluation/shared/search_engines/vespa_search_engine.py
@@ -10,7 +10,7 @@ from pydantic import HttpUrl
 
 from llm_search_quality_evaluation.shared.search_engines.search_engine_base import BaseSearchEngine
 from llm_search_quality_evaluation.shared.models.document import Document
-from llm_search_quality_evaluation.shared.utils import clean_text
+from llm_search_quality_evaluation.shared.utils import clean_text, normalize_discovered_field_values
 
 
 log = logging.getLogger(__name__)
@@ -27,6 +27,11 @@ class VespaSearchEngine(BaseSearchEngine):
     Thin HTTP wrapper around the Vespa Query API.
     Assumes an already deployed a schema called `doc`.
     """
+
+    # Vespa YQL uses parameter-binding syntax (e.g. `userInput(@kw)`) rather than the
+    # `$query` string-replace convention used by Solr / Elasticsearch / OpenSearch.
+    QUERY_PLACEHOLDER: str = "@kw"
+
     def __init__(self, endpoint: HttpUrl):
         super().__init__(endpoint)
         # Extract schema from endpoint path: http://host:port/schema_name/
@@ -70,7 +75,16 @@ class VespaSearchEngine(BaseSearchEngine):
         return int(response.json().get("root", {}).get("fields", {}).get("totalCount", 0))
 
     def _build_yql(self, select_fields: List[str], where_clause: str = "true") -> str:
-        fields = ", ".join(select_fields) if select_fields else "*"
+        # Always project Vespa's built-in `documentid` summary field so `_search` can
+        # surface the user document id (`id:ns:type::user`) instead of the internal GID
+        # (`index:schema/0/<hash>`) that `hit["id"]` falls back to under restricted projections.
+        if select_fields:
+            projected = list(select_fields)
+            if "documentid" not in projected:
+                projected.insert(0, "documentid")
+            fields = ", ".join(projected)
+        else:
+            fields = "*"
         return f"select {fields} from {self.schema} where {where_clause}"
 
     @staticmethod
@@ -204,6 +218,80 @@ class VespaSearchEngine(BaseSearchEngine):
         return self._search(payload)
 
 
+    def fetch_field_values(self, values_query_template: Path | str, field: str) -> List[str]:
+        """Run a Vespa grouping query and return distinct values for ``field``.
+
+        The template contains YQL only — the engine wraps it with ``hits=0`` and
+        ``presentation.format=json`` automatically (YQL itself can't express those).
+        Vespa grouping requires the grouped field to be an ``attribute`` in the .sd schema;
+        a non-attribute field will fail at Vespa, not here.
+
+        Response shape (nested under ``group:root:0``):
+            root.children[]
+               group:root:0
+                   children[]
+                       grouplist:<field>
+                           children[]
+                               group:string:<value>
+                                   value: "<value>"
+        We do a recursive walk for any node whose ``id == 'grouplist:<field>'`` or
+        ``label == field`` and return each child's ``value``.
+        """
+        path = Path(values_query_template)
+        yql = path.read_text(encoding="utf-8").strip()
+
+        payload: Dict[str, Any] = {
+            "yql": yql,
+            "hits": 0,
+            "presentation.format": "json",
+        }
+
+        base = str(self.endpoint).rstrip("/")
+        search_url = f"{base}/search/"
+
+        log.debug(f"[fetch_field_values] Vespa POST {search_url} payload={str(payload)[:500]}")
+
+        try:
+            response = requests.post(
+                search_url,
+                headers=self.HEADERS,
+                json=payload,
+                timeout=DEFAULT_TIMEOUT,
+                allow_redirects=False,
+            )
+            response.raise_for_status()
+        except (ConnectionError, Timeout, RequestException) as e:
+            log.error(f"Vespa value-discovery query to {search_url} failed: {e}")
+            raise
+
+        body = response.json()
+        seen: List[str] = []
+        grouplist = self._find_grouplist(body.get("root", {}), field, seen)
+        if grouplist is None:
+            raise ValueError(
+                f"Vespa value-discovery: no grouplist found for field '{field}'. "
+                f"Encountered nodes: {[s for s in seen if s]}. "
+                f"Note: Vespa grouping requires the grouped field to be an attribute in the schema."
+            )
+        return normalize_discovered_field_values(
+            b.get("value") for b in (grouplist.get("children") or [])
+        )
+
+    @staticmethod
+    def _find_grouplist(node: Any, field: str, seen: List[str]) -> Optional[Dict[str, Any]]:
+        if isinstance(node, dict):
+            if str(node.get("id", "")) == f"grouplist:{field}" or node.get("label") == field:
+                return node
+            label = node.get("id") or node.get("label")
+            if label is not None:
+                seen.append(str(label))
+            for child in node.get("children", []) or []:
+                found = VespaSearchEngine._find_grouplist(child, field, seen)
+                if found is not None:
+                    return found
+        return None
+
+
     # ---- low‑level call --------------------------------------------------
 
     def _search(self, payload: Dict[str, Any]) -> List[Document]:
@@ -240,11 +328,14 @@ class VespaSearchEngine(BaseSearchEngine):
         hits = (raw_response.get("root") or {}).get("children") or []
         docs: List[Document] = []
         for hit in hits:
-            doc_id = hit.get("id")
+            fields = hit.get("fields", {}) or {}
+            # Prefer the user document id from `fields.documentid` (always projected by `_build_yql`).
+            # Fall back to `hit["id"]` so callers that bypass `_build_yql` (or hit a Vespa version
+            # that omits the summary field) still get something usable, even if it's the GID form.
+            doc_id = fields.get("documentid") or hit.get("id")
             if not doc_id:
                 log.debug(f"Potential corrupted entry without id in Vespa _search: {hit}")
                 continue
-            fields = hit.get("fields", {}) or {}
 
             normalized_fields = {k: self._normalize_field_value(v) for k, v in fields.items()}
             docs.append(Document(id=doc_id, fields=normalized_fields))

--- a/src/llm_search_quality_evaluation/shared/utils.py
+++ b/src/llm_search_quality_evaluation/shared/utils.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Iterable, List
 import re
 import html
 import unicodedata
@@ -52,6 +52,45 @@ def clean_text(text: str) -> str:
     # Normalize whitespace
     t = _WS_REGEX.sub(" ", t).strip()
     return t
+
+def normalize_discovered_field_values(values: Iterable[Any]) -> List[str]:
+    """Normalize bucket keys returned by an engine's value-discovery query.
+
+    Used by `BaseSearchEngine.fetch_field_values` implementations to turn raw bucket keys
+    (Solr facet values, ES/OS aggregation `bucket.key`, Vespa grouping `bucket.value`) into
+    `List[str]` that downstream string substitution can safely consume.
+
+    This is intentionally separate from the per-engine `Document.fields` normalizers
+    (`SolrSearchEngine._normalize`, `VespaSearchEngine._normalize_field_value`, etc.):
+    those preserve containers as JSON; this rejects them so a misconfigured aggregation that
+    produces nested buckets surfaces as a `ValueError` rather than landing
+    `"{'key': 'comedy'}"` as a query.
+
+    Steps (in order):
+      1. Drop None.
+      2. Accept only str/int/float/bool. Raise ValueError on list/dict/other containers.
+      3. str(value) on accepted scalars.
+      4. Strip surrounding whitespace.
+      5. Drop empty strings after stripping.
+      6. Preserve input order. No sorting, no deduping (DataStore.add_query handles dedupe
+         via clean_text on the rendered query text).
+    """
+    out: List[str] = []
+    for v in values:
+        if v is None:
+            continue
+        if isinstance(v, bool) or isinstance(v, (int, float, str)):
+            stripped = str(v).strip()
+            if stripped:
+                out.append(stripped)
+            continue
+        raise ValueError(
+            f"normalize_discovered_field_values: unsupported bucket value type {type(v).__name__} "
+            f"({v!r}). Only scalars (str, int, float, bool) are supported; nested containers "
+            f"indicate a compound aggregation, which is not supported."
+        )
+    return out
+
 
 def join_fields_as_text(fields: dict[str, Any], exclude: set[str] | str) -> str:
     if isinstance(exclude, str):

--- a/tests/llm_search_quality_evaluation/dataset_generator/category_query_test_utils.py
+++ b/tests/llm_search_quality_evaluation/dataset_generator/category_query_test_utils.py
@@ -1,0 +1,135 @@
+"""Shared helpers for category-query and main() wiring tests (not collected by pytest)."""
+
+from __future__ import annotations
+
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from typing import List
+
+from llm_search_quality_evaluation.dataset_generator import main as main_mod
+from llm_search_quality_evaluation.dataset_generator.config import Config
+from llm_search_quality_evaluation.shared.models import Document
+
+
+def llm_cfg(tmp_path: Path) -> Path:
+    p = tmp_path / "llm_cfg.yaml"
+    p.write_text("name: mock\nmodel: mock-model\nmax_tokens: 16\n", encoding="utf-8")
+    return p
+
+
+def genre_query_template(tmp_path: Path) -> Path:
+    p = tmp_path / "genre_query.tmpl"
+    p.write_text("$query movies\n", encoding="utf-8")
+    return p
+
+
+def make_config(tmp_path: Path, **overrides) -> Config:
+    base = dict(
+        query_template=None,
+        search_engine_type="solr",
+        collection_name="testcore",
+        search_engine_url="http://localhost:8983/solr/",
+        documents_filter=None,
+        number_of_docs=2,
+        doc_fields=["title", "genres"],
+        queries=None,
+        generate_queries_from_documents=True,
+        num_queries_needed=10,
+        relevance_scale="graded",
+        llm_configuration_file=llm_cfg(tmp_path),
+        output_format="quepid",
+        output_destination=tmp_path,
+        save_llm_explanation=False,
+        llm_explanation_destination=None,
+        id_field=None,
+        rre_query_template=None,
+        rre_query_placeholder=None,
+        verbose=False,
+        datastore_autosave_every_n_updates=None,
+        enable_cartesian_product=True,
+    )
+    base.update(overrides)
+    return Config(**base)
+
+
+class FakeSearchEngine:
+    def __init__(self, docs: List[Document]):
+        self._docs = docs
+        self.fetch_calls = 0
+
+    def fetch_for_query_generation(self, documents_filter, number_of_docs, doc_fields):
+        self.fetch_calls += 1
+        return list(self._docs)
+
+    def fetch_field_values(self, values_query_template, field):
+        raise AssertionError(
+            "fetch_field_values should not be called for explicit-values configs"
+        )
+
+
+class FakeLLMService:
+    def __init__(self, queries_per_doc=None, score=2):
+        self._queries_per_doc = queries_per_doc or {}
+        self._score = score
+        self.generate_queries_calls = []
+        self.generate_score_calls = []
+
+    def generate_queries(self, doc, num_queries_per_doc, max_query_terms):
+        self.generate_queries_calls.append(doc.id)
+        queries = self._queries_per_doc.get(doc.id, [f"q-from-{doc.id}"])
+        return SimpleNamespace(get_queries=lambda: queries)
+
+    def generate_score(self, document, query, relevance_scale, explanation=False):
+        self.generate_score_calls.append((document.id, query))
+        score = self._score
+        return SimpleNamespace(score=score, explanation=None, get_score=lambda: score)
+
+
+class DummyWriter:
+    def write(self, output_destination, data_store):
+        return None
+
+
+def patch_main_dependencies(monkeypatch, cfg, search_engine, llm_service, *,
+                             stub_cartesian: bool = True):
+    monkeypatch.setattr(main_mod, "Config", types.SimpleNamespace(load=lambda _path: cfg))
+    monkeypatch.setattr(
+        main_mod, "parse_args",
+        lambda: types.SimpleNamespace(config="ignored.yaml", verbose=False),
+    )
+    monkeypatch.setattr(
+        main_mod, "SearchEngineFactory",
+        types.SimpleNamespace(build=lambda **kwargs: search_engine),
+    )
+    monkeypatch.setattr(main_mod, "LLMConfig", types.SimpleNamespace(load=lambda _path: object()))
+    monkeypatch.setattr(
+        main_mod, "LLMServiceFactory",
+        types.SimpleNamespace(build_lazy=lambda _cfg: object()),
+    )
+    monkeypatch.setattr(main_mod, "LLMService", lambda chat_model: llm_service)
+    monkeypatch.setattr(
+        main_mod, "WriterFactory",
+        types.SimpleNamespace(build=lambda _cfg: DummyWriter()),
+    )
+    if stub_cartesian:
+        monkeypatch.setattr(main_mod, "add_cartesian_product_scores", lambda *a, **kw: None)
+    monkeypatch.setattr(main_mod, "expand_docset_with_search_engine_top_k", lambda *a, **kw: None)
+
+
+class ValueDiscoveryEngine:
+    """Engine fake exposing only `fetch_field_values` (value-discovery path)."""
+
+    def __init__(self, values_by_field=None):
+        self._values_by_field = values_by_field or {}
+        self.calls = []
+
+    def fetch_field_values(self, values_query_template, field):
+        self.calls.append((values_query_template, field))
+        return list(self._values_by_field.get(field, []))
+
+
+def empty_solr_facet_template(tmp_path: Path) -> Path:
+    p = tmp_path / "facet_solr.json"
+    p.write_text('{"q": "*:*", "facet": "true", "facet.field": "genres", "rows": 0}\n', encoding="utf-8")
+    return p

--- a/tests/llm_search_quality_evaluation/dataset_generator/conftest.py
+++ b/tests/llm_search_quality_evaluation/dataset_generator/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 from pathlib import Path
 
+
 @pytest.fixture
 def resource_folder():
     return Path(__file__).parent.parent.parent / "resources"

--- a/tests/llm_search_quality_evaluation/dataset_generator/llm/test_batch_prompt_validation.py
+++ b/tests/llm_search_quality_evaluation/dataset_generator/llm/test_batch_prompt_validation.py
@@ -1,0 +1,110 @@
+"""Unit tests for `validate_batch_prompt_template`.
+
+The validator enforces a *closed* placeholder grammar at config load: each
+field reference must be exactly one of the allowed names with no attribute
+access, item access, conversion, or format spec. The tests below cover each
+rejected variant — most importantly the silent-corruption case
+`{documents_json[0]}`, which would render only the first character of the
+JSON payload at runtime if it slipped through.
+"""
+from __future__ import annotations
+
+import pytest
+
+from llm_search_quality_evaluation.dataset_generator.llm import validate_batch_prompt_template
+
+
+REQUIRED_BODY = (
+    "Query: {query}\n"
+    "Docs: {documents_json}\n"
+    "Scale: {relevance_scale}\n"
+)
+
+
+def test_minimal_valid_template__passes():
+    validate_batch_prompt_template(REQUIRED_BODY)
+
+
+def test_template_with_optional_placeholders__passes():
+    body = REQUIRED_BODY + "{explanation_instruction}\n{rating_scale_description}\n"
+    validate_batch_prompt_template(body)
+
+
+def test_template_with_escaped_braces__passes():
+    body = REQUIRED_BODY + 'Literal braces are fine: {{"k": "v"}}\n'
+    validate_batch_prompt_template(body)
+
+
+def test_missing_required_placeholder__rejected():
+    body = "Query: {query}\nScale: {relevance_scale}\n"  # no documents_json
+    with pytest.raises(ValueError, match="required placeholder"):
+        validate_batch_prompt_template(body)
+
+
+def test_unknown_placeholder_name__rejected():
+    body = REQUIRED_BODY + "Mystery: {documents}\n"
+    with pytest.raises(ValueError, match="unsupported placeholder"):
+        validate_batch_prompt_template(body)
+
+
+def test_unescaped_json_braces__rejected():
+    body = REQUIRED_BODY + 'Example: {"id": 1}\n'
+    with pytest.raises(ValueError):
+        validate_batch_prompt_template(body)
+
+
+def test_attribute_access_on_known_placeholder__rejected():
+    # Without exact-match validation this used to pass, then raise at runtime
+    # with `AttributeError: 'str' object has no attribute 'nope'`.
+    body = REQUIRED_BODY + "Bad: {query.nope}\n"
+    with pytest.raises(ValueError, match="unsupported placeholder"):
+        validate_batch_prompt_template(body)
+
+
+def test_item_access_on_known_placeholder__rejected():
+    # The silent-corruption case: `{documents_json[0]}` renders only the first
+    # character of the JSON payload at runtime. Must be caught at config load.
+    body = (
+        "Query: {query}\n"
+        "Docs: {documents_json[0]}\n"
+        "Scale: {relevance_scale}\n"
+    )
+    with pytest.raises(ValueError, match="unsupported placeholder"):
+        validate_batch_prompt_template(body)
+
+
+def test_conversion_on_placeholder__rejected():
+    body = (
+        "Query: {query!r}\n"
+        "Docs: {documents_json}\n"
+        "Scale: {relevance_scale}\n"
+    )
+    with pytest.raises(ValueError, match="unsupported conversion"):
+        validate_batch_prompt_template(body)
+
+
+def test_format_spec_on_placeholder__rejected():
+    body = (
+        "Query: {query:>10}\n"
+        "Docs: {documents_json}\n"
+        "Scale: {relevance_scale}\n"
+    )
+    with pytest.raises(ValueError, match="unsupported format spec"):
+        validate_batch_prompt_template(body)
+
+
+def test_nested_format_spec__rejected():
+    # `{query:{width}}` raises `KeyError: 'width'` only when format() runs.
+    body = (
+        "Query: {query:{width}}\n"
+        "Docs: {documents_json}\n"
+        "Scale: {relevance_scale}\n"
+    )
+    with pytest.raises(ValueError, match="unsupported format spec"):
+        validate_batch_prompt_template(body)
+
+
+def test_positional_placeholder__rejected():
+    body = "Query: {} {documents_json} {relevance_scale}\n"
+    with pytest.raises(ValueError, match="positional placeholder"):
+        validate_batch_prompt_template(body)

--- a/tests/llm_search_quality_evaluation/dataset_generator/llm/test_default_batch_score_prompt.py
+++ b/tests/llm_search_quality_evaluation/dataset_generator/llm/test_default_batch_score_prompt.py
@@ -1,0 +1,19 @@
+"""Guard against accidental breakage of the built-in batch-scoring prompt."""
+from __future__ import annotations
+
+from llm_search_quality_evaluation.dataset_generator.llm import (
+    DEFAULT_BATCH_SCORE_PROMPT,
+    validate_batch_prompt_template,
+)
+
+
+def test_default_batch_score_prompt__passes_config_load_validation():
+    # If this raises, a future edit to DEFAULT_BATCH_SCORE_PROMPT broke the
+    # placeholder contract (typo, unescaped JSON braces, missing required).
+    validate_batch_prompt_template(DEFAULT_BATCH_SCORE_PROMPT)
+
+
+def test_default_batch_score_prompt__contains_required_placeholders():
+    # Belt-and-braces: substring check too, in case Formatter ever changes.
+    for required in ("{query}", "{documents_json}", "{relevance_scale}"):
+        assert required in DEFAULT_BATCH_SCORE_PROMPT

--- a/tests/llm_search_quality_evaluation/dataset_generator/llm/test_llm_factory.py
+++ b/tests/llm_search_quality_evaluation/dataset_generator/llm/test_llm_factory.py
@@ -1,3 +1,7 @@
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+
 import pytest
 from pydantic_core import ValidationError
 
@@ -60,3 +64,53 @@ def test_llm_factory_lazy_openai__expected__api_key_not_valid(example_doc, query
     service: LLMService = LLMService(chat_model=llm)
     with pytest.raises(ValueError):
         _ = service.generate_score(example_doc, query, relevance_scale='binary')
+
+
+def test_lazy_llm_builds_model_once_under_concurrency(monkeypatch):
+    """Concurrent first-use of LazyLLM.llm must build the underlying model exactly once.
+
+    The PR runs scoring / query-gen through a ThreadPoolExecutor when llm_max_workers > 1.
+    Without the double-checked lock in LazyLLM.llm, racing workers could each see
+    `_llm is None` and call LLMServiceFactory.build redundantly. This asserts a single build.
+    """
+    cfg = LLMConfig(
+        name="openai",
+        model="mock_model",
+        max_tokens=1024,
+        api_key_env="mock_api_key",
+    )
+
+    build_calls = 0
+    build_calls_lock = threading.Lock()
+
+    class _DummyModel:
+        def with_structured_output(self, *_args, **_kwargs):
+            return self
+
+    def fake_build(config):
+        nonlocal build_calls
+        with build_calls_lock:
+            build_calls += 1
+        # Widen the race window so a missing lock would be caught reliably.
+        time.sleep(0.01)
+        return _DummyModel()
+
+    monkeypatch.setattr(LLMServiceFactory, "build", staticmethod(fake_build))
+    # Isolate from the class-level cache: construct LazyLLM directly so this test's result
+    # cannot be influenced by (or leak into) LLMServiceFactory._cached_lazy_llm.
+    monkeypatch.setattr(LLMServiceFactory, "_cached_lazy_llm", None, raising=False)
+
+    lazy = LazyLLM(cfg)
+
+    n_workers = 16
+    barrier = threading.Barrier(n_workers)
+
+    def worker():
+        barrier.wait()  # release all threads together to maximize the race
+        return lazy.with_structured_output(object)
+
+    with ThreadPoolExecutor(max_workers=n_workers) as executor:
+        results = [f.result() for f in [executor.submit(worker) for _ in range(n_workers)]]
+
+    assert build_calls == 1
+    assert all(r is not None for r in results)

--- a/tests/llm_search_quality_evaluation/dataset_generator/llm/test_llm_service_batch_score.py
+++ b/tests/llm_search_quality_evaluation/dataset_generator/llm/test_llm_service_batch_score.py
@@ -1,0 +1,307 @@
+"""Tests for `LLMService.generate_scores_batch` and `BatchScoringError`."""
+from __future__ import annotations
+
+import json
+from typing import List
+
+import pytest
+from langchain_core.language_models.fake_chat_models import FakeListChatModel
+
+from llm_search_quality_evaluation.dataset_generator.llm import (
+    BatchScoringError,
+    DEFAULT_BATCH_SCORE_PROMPT,
+    LLMService,
+)
+from llm_search_quality_evaluation.dataset_generator.models import LLMScoreResponse
+from llm_search_quality_evaluation.shared.models import Document
+
+from llm_mock import FakeChatModelAdapter
+
+
+@pytest.fixture
+def docs() -> List[Document]:
+    return [
+        Document(id=f"d{i}", fields={"title": f"Title {i}"}) for i in range(10)
+    ]
+
+
+def _make_service(responses):
+    fake_llm = FakeListChatModel(responses=list(responses))
+    return LLMService(chat_model=FakeChatModelAdapter(fake_llm))
+
+
+def _clean_response(doc_ids, explanation: bool = False, score: int = 1) -> str:
+    items = []
+    for did in doc_ids:
+        item: dict = {"doc_id": did, "score": score}
+        if explanation:
+            item["explanation"] = f"why {did}"
+        items.append(item)
+    return json.dumps({"ratings": items})
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+    """Default to instant sleeps for unit tests."""
+    monkeypatch.setattr(
+        "llm_search_quality_evaluation.dataset_generator.llm.llm_service.time.sleep", lambda _d: None
+    )
+
+
+def test_generate_scores_batch__happy_path__maps_scores_by_doc_id(docs):
+    response = _clean_response([d.id for d in docs], score=1)
+    service = _make_service([response])
+
+    out = service.generate_scores_batch(
+        query_id="q1", query_text="hello", documents=docs,
+        relevance_scale="binary", explanation=False,
+        prompt_template=DEFAULT_BATCH_SCORE_PROMPT, max_retries=3,
+    )
+
+    assert set(out.keys()) == {d.id for d in docs}
+    for d in docs:
+        assert isinstance(out[d.id], LLMScoreResponse)
+        assert out[d.id].get_score() == 1
+        assert out[d.id].explanation is None
+
+
+def test_generate_scores_batch__shuffled_response__still_maps_by_doc_id(docs):
+    shuffled_ids = list(reversed([d.id for d in docs]))
+    response = _clean_response(shuffled_ids, score=2)
+    service = _make_service([response])
+
+    out = service.generate_scores_batch(
+        query_id="q1", query_text="hi", documents=docs,
+        relevance_scale="graded", explanation=False,
+        prompt_template=DEFAULT_BATCH_SCORE_PROMPT, max_retries=3,
+    )
+
+    assert set(out.keys()) == {d.id for d in docs}
+    assert all(out[did].get_score() == 2 for did in (d.id for d in docs))
+
+
+def test_generate_scores_batch__missing_doc_id_then_clean__retries_and_succeeds(docs):
+    asked = [d.id for d in docs]
+    bad = _clean_response(asked[:-1])  # missing the last one
+    good = _clean_response(asked)
+    service = _make_service([bad, good])
+
+    out = service.generate_scores_batch(
+        query_id="q1", query_text="x", documents=docs,
+        relevance_scale="binary", explanation=False,
+        prompt_template=DEFAULT_BATCH_SCORE_PROMPT, max_retries=3,
+    )
+
+    assert set(out.keys()) == set(asked)
+
+
+def test_generate_scores_batch__unknown_doc_id_then_clean__retries_and_succeeds(docs):
+    asked = [d.id for d in docs]
+    bad = _clean_response(asked + ["hallucinated-id"])
+    good = _clean_response(asked)
+    service = _make_service([bad, good])
+
+    out = service.generate_scores_batch(
+        query_id="q1", query_text="x", documents=docs,
+        relevance_scale="binary", explanation=False,
+        prompt_template=DEFAULT_BATCH_SCORE_PROMPT, max_retries=3,
+    )
+
+    assert set(out.keys()) == set(asked)
+
+
+def test_generate_scores_batch__duplicate_doc_id_then_clean__retries_and_succeeds(docs):
+    asked = [d.id for d in docs]
+    bad = _clean_response(asked + [asked[0]])  # d0 twice
+    good = _clean_response(asked)
+    service = _make_service([bad, good])
+
+    out = service.generate_scores_batch(
+        query_id="q1", query_text="x", documents=docs,
+        relevance_scale="binary", explanation=False,
+        prompt_template=DEFAULT_BATCH_SCORE_PROMPT, max_retries=3,
+    )
+
+    assert set(out.keys()) == set(asked)
+
+
+def test_generate_scores_batch__invocation_failure_then_clean__retries_and_succeeds(docs):
+    asked = [d.id for d in docs]
+    good = _clean_response(asked)
+    # First payload is invalid JSON for the schema -> ValidationError inside _StructuredOutputMockLLM
+    service = _make_service(['{"this": "is not a ratings response"}', good])
+
+    out = service.generate_scores_batch(
+        query_id="q1", query_text="x", documents=docs,
+        relevance_scale="binary", explanation=False,
+        prompt_template=DEFAULT_BATCH_SCORE_PROMPT, max_retries=3,
+    )
+
+    assert set(out.keys()) == set(asked)
+
+
+def test_generate_scores_batch__persistent_failure__raises_batch_scoring_error(docs):
+    asked = [d.id for d in docs]
+    bad = _clean_response(asked[:-1])  # always missing one
+    # max_retries=2 → 3 total attempts; provide 3 identically-broken responses.
+    service = _make_service([bad, bad, bad])
+
+    with pytest.raises(BatchScoringError) as exc_info:
+        service.generate_scores_batch(
+            query_id="q1", query_text="x", documents=docs,
+            relevance_scale="binary", explanation=False,
+            prompt_template=DEFAULT_BATCH_SCORE_PROMPT, max_retries=2,
+        )
+
+    err = exc_info.value
+    assert err.query_id == "q1"
+    assert err.batch_size == len(docs)
+    assert err.asked_doc_ids == asked
+    assert err.attempts == 3
+    assert "missing" in err.reason.lower()
+
+
+def test_generate_scores_batch__response_contract_failure__chains_cause(docs):
+    """Regression: __cause__ should be populated even for missing/unknown/duplicate
+    doc_id failures, not only for invocation failures, so traceback inspection
+    and any cause-aware tooling behave uniformly across failure classes."""
+    asked = [d.id for d in docs]
+    bad = _clean_response(asked[:-1])  # missing one
+    service = _make_service([bad])
+
+    with pytest.raises(BatchScoringError) as exc_info:
+        service.generate_scores_batch(
+            query_id="q1", query_text="x", documents=docs,
+            relevance_scale="binary", explanation=False,
+            prompt_template=DEFAULT_BATCH_SCORE_PROMPT, max_retries=0,
+        )
+
+    cause = exc_info.value.__cause__
+    assert cause is not None
+    assert "missing" in str(cause).lower()
+
+
+def test_generate_scores_batch__invocation_failure__chains_provider_exception(docs):
+    """The other half of the contract: invocation failures should chain the
+    real provider exception, not a synthetic one."""
+    service = _make_service(['{"this": "is not a ratings response"}'])
+
+    with pytest.raises(BatchScoringError) as exc_info:
+        service.generate_scores_batch(
+            query_id="q1", query_text="x", documents=docs,
+            relevance_scale="binary", explanation=False,
+            prompt_template=DEFAULT_BATCH_SCORE_PROMPT, max_retries=0,
+        )
+
+    # The real cause is a pydantic ValidationError from model_validate_json.
+    cause = exc_info.value.__cause__
+    assert cause is not None
+    assert "ValidationError" in type(cause).__name__ or isinstance(cause, ValueError)
+
+
+def test_generate_scores_batch__retry_uses_exponential_backoff(monkeypatch, docs):
+    sleeps: list[float] = []
+    monkeypatch.setattr(
+        "llm_search_quality_evaluation.dataset_generator.llm.llm_service.time.sleep",
+        lambda d: sleeps.append(d),
+    )
+    # Pin jitter to 0 so we get exactly base * 2**attempt.
+    monkeypatch.setattr(
+        "llm_search_quality_evaluation.dataset_generator.llm.llm_service.random.uniform",
+        lambda _a, _b: 0.0,
+    )
+
+    asked = [d.id for d in docs]
+    bad = _clean_response(asked[:-1])
+    # max_retries=3 → 4 attempts; all bad → 3 sleeps (no sleep after the last attempt).
+    service = _make_service([bad, bad, bad, bad])
+    with pytest.raises(BatchScoringError):
+        service.generate_scores_batch(
+            query_id="q1", query_text="x", documents=docs,
+            relevance_scale="binary", explanation=False,
+            prompt_template=DEFAULT_BATCH_SCORE_PROMPT, max_retries=3,
+        )
+
+    # Base = 1.0; attempts 0,1,2 -> 1, 2, 4.
+    assert sleeps == [1.0, 2.0, 4.0]
+
+
+def test_generate_scores_batch__explanation_true__returns_explanations(docs):
+    asked = [d.id for d in docs[:3]]
+    response = _clean_response(asked, explanation=True, score=1)
+    service = _make_service([response])
+
+    out = service.generate_scores_batch(
+        query_id="q1", query_text="x", documents=docs[:3],
+        relevance_scale="binary", explanation=True,
+        prompt_template=DEFAULT_BATCH_SCORE_PROMPT, max_retries=0,
+    )
+
+    for did in asked:
+        exp = out[did].explanation
+        # Plan note: per-item explanation is Optional[str] in the schema.
+        assert exp is None or (isinstance(exp, str) and exp != "")
+        assert exp == f"why {did}"
+
+
+def test_generate_scores_batch__blank_explanation_item__normalized_to_none_not_raised(docs):
+    """Regression: provider returns explanation="" for one item when the user
+    asked for explanations. Before the LLMScoreResponse normalization, this
+    raised a non-retryable ValueError out of result assembly, bypassing the
+    BatchScoringError contract. Now it should silently come through as None
+    for that doc — the plan permits per-item explanations to be missing."""
+    asked = [d.id for d in docs[:3]]
+    response_json = (
+        '{"ratings": ['
+        f'{{"doc_id": "{asked[0]}", "score": 1, "explanation": "real reason"}},'
+        f'{{"doc_id": "{asked[1]}", "score": 1, "explanation": ""}},'
+        f'{{"doc_id": "{asked[2]}", "score": 1, "explanation": "   "}}'
+        ']}'
+    )
+    service = _make_service([response_json])
+
+    out = service.generate_scores_batch(
+        query_id="q1", query_text="x", documents=docs[:3],
+        relevance_scale="binary", explanation=True,
+        prompt_template=DEFAULT_BATCH_SCORE_PROMPT, max_retries=0,
+    )
+
+    assert out[asked[0]].explanation == "real reason"
+    assert out[asked[1]].explanation is None
+    assert out[asked[2]].explanation is None
+
+
+def test_generate_scores_batch__explanation_false__returns_none(docs):
+    asked = [d.id for d in docs[:3]]
+    # Even if the model included explanations, the service should suppress them.
+    response = _clean_response(asked, explanation=True, score=1)
+    service = _make_service([response])
+
+    out = service.generate_scores_batch(
+        query_id="q1", query_text="x", documents=docs[:3],
+        relevance_scale="binary", explanation=False,
+        prompt_template=DEFAULT_BATCH_SCORE_PROMPT, max_retries=0,
+    )
+
+    for did in asked:
+        assert out[did].explanation is None
+
+
+def test_generate_scores_batch__invalid_relevance_scale__raises_value_error(docs):
+    service = _make_service([])
+    with pytest.raises(ValueError, match="Invalid relevance scale"):
+        service.generate_scores_batch(
+            query_id="q1", query_text="x", documents=docs,
+            relevance_scale="fuzzy", explanation=False,
+            prompt_template=DEFAULT_BATCH_SCORE_PROMPT, max_retries=0,
+        )
+
+
+def test_generate_scores_batch__empty_documents__returns_empty():
+    service = _make_service([])
+    out = service.generate_scores_batch(
+        query_id="q1", query_text="x", documents=[],
+        relevance_scale="binary", explanation=False,
+        prompt_template=DEFAULT_BATCH_SCORE_PROMPT, max_retries=0,
+    )
+    assert out == {}

--- a/tests/llm_search_quality_evaluation/dataset_generator/models/test_score_response.py
+++ b/tests/llm_search_quality_evaluation/dataset_generator/models/test_score_response.py
@@ -1,0 +1,45 @@
+"""Tests for `LLMScoreResponse` construction and explanation normalization.
+
+The blank-string normalization matters for the batch flow: providers can
+return ``explanation=""`` instead of omitting the field, and the batch
+result-assembly path used to raise a non-retryable ValueError on that input.
+Normalizing ``""`` (or whitespace-only) to ``None`` matches the plan's
+already-permitted "per-item explanation may be missing" contract and keeps
+the single-pair flow consistent.
+"""
+from __future__ import annotations
+
+import pytest
+
+from llm_search_quality_evaluation.dataset_generator.models import LLMScoreResponse
+
+
+@pytest.mark.parametrize("blank", ["", " ", "\t", "\n", "   \n\t  "])
+def test_blank_or_whitespace_explanation__normalized_to_none(blank):
+    resp = LLMScoreResponse(score=1, scale="binary", explanation=blank)
+    assert resp.explanation is None
+
+
+def test_none_explanation__stays_none():
+    resp = LLMScoreResponse(score=1, scale="binary", explanation=None)
+    assert resp.explanation is None
+
+
+def test_non_empty_explanation__preserved():
+    resp = LLMScoreResponse(score=2, scale="graded", explanation="because reasons")
+    assert resp.explanation == "because reasons"
+
+
+def test_non_string_explanation__rejected():
+    with pytest.raises(ValueError, match="must be a string"):
+        LLMScoreResponse(score=1, scale="binary", explanation=123)  # type: ignore[arg-type]
+
+
+def test_invalid_scale__rejected():
+    with pytest.raises(ValueError, match="Invalid scale"):
+        LLMScoreResponse(score=1, scale="fuzzy", explanation=None)
+
+
+def test_score_out_of_range_for_scale__rejected():
+    with pytest.raises(ValueError, match="binary scale"):
+        LLMScoreResponse(score=2, scale="binary", explanation=None)

--- a/tests/llm_search_quality_evaluation/dataset_generator/test_add_category_queries.py
+++ b/tests/llm_search_quality_evaluation/dataset_generator/test_add_category_queries.py
@@ -1,0 +1,150 @@
+from pathlib import Path
+
+from llm_search_quality_evaluation.dataset_generator.query_sources import add_category_queries
+from llm_search_quality_evaluation.shared.data_store import DataStore
+
+from category_query_test_utils import (
+    FakeSearchEngine,
+    ValueDiscoveryEngine,
+    empty_solr_facet_template,
+    genre_query_template,
+    make_config,
+)
+
+
+def test_add_category_queries__renders_and_dedupes(tmp_path):
+    template = genre_query_template(tmp_path)
+    cfg = make_config(
+        tmp_path,
+        category_queries=[
+            {"fields": ["genres"], "values": ["comedy", "action", "comedy"],
+             "query_text_template_file": str(template)},
+        ],
+    )
+    ds = DataStore(path=tmp_path / "ds.json", ignore_saved_data=True)
+    engine = FakeSearchEngine([])
+
+    add_category_queries(cfg, ds, engine)
+
+    texts = sorted(q.text for q in ds.get_queries())
+    assert texts == ["action movies", "comedy movies"]
+
+
+def test_add_category_queries__none_is_noop(tmp_path):
+    cfg = make_config(tmp_path, category_queries=None)
+    ds = DataStore(path=tmp_path / "ds.json", ignore_saved_data=True)
+    engine = FakeSearchEngine([])
+    add_category_queries(cfg, ds, engine)
+    assert ds.get_queries() == []
+
+
+def test_add_category_queries__bare_values_when_template_omitted(tmp_path):
+    cfg = make_config(
+        tmp_path,
+        category_queries=[
+            {"fields": ["genres"], "values": ["comedy", "action"]},
+        ],
+    )
+    ds = DataStore(path=tmp_path / "ds.json", ignore_saved_data=True)
+    engine = FakeSearchEngine([])
+
+    add_category_queries(cfg, ds, engine)
+
+    texts = sorted(q.text for q in ds.get_queries())
+    assert texts == ["action", "comedy"]
+    assert all(q.source == "category" for q in ds.get_queries())
+
+
+def test_add_category_queries__engine_discovery_calls_fetch_field_values_once_per_source(tmp_path):
+    facet = empty_solr_facet_template(tmp_path)
+    cfg = make_config(
+        tmp_path,
+        category_queries=[
+            {"fields": ["genres"], "values_query_template_file": str(facet)},
+        ],
+    )
+    ds = DataStore(path=tmp_path / "ds.json", ignore_saved_data=True)
+    engine = ValueDiscoveryEngine(values_by_field={"genres": ["comedy", "action"]})
+
+    add_category_queries(cfg, ds, engine)
+
+    assert len(engine.calls) == 1
+    template_arg, field_arg = engine.calls[0]
+    assert Path(template_arg) == facet
+    assert field_arg == "genres"
+    texts = sorted(q.text for q in ds.get_queries())
+    assert texts == ["action", "comedy"]
+    assert all(q.source == "category" for q in ds.get_queries())
+
+
+def test_add_category_queries__engine_discovery_renders_through_query_text_template(tmp_path):
+    facet = empty_solr_facet_template(tmp_path)
+    template = genre_query_template(tmp_path)
+    cfg = make_config(
+        tmp_path,
+        category_queries=[
+            {"fields": ["genres"], "values_query_template_file": str(facet),
+             "query_text_template_file": str(template)},
+        ],
+    )
+    ds = DataStore(path=tmp_path / "ds.json", ignore_saved_data=True)
+    engine = ValueDiscoveryEngine(values_by_field={"genres": ["comedy", "action"]})
+
+    add_category_queries(cfg, ds, engine)
+
+    assert sorted(q.text for q in ds.get_queries()) == ["action movies", "comedy movies"]
+
+
+def test_add_category_queries__engine_discovery_empty_result_warns_and_skips_source(tmp_path, caplog):
+    facet = empty_solr_facet_template(tmp_path)
+    template = genre_query_template(tmp_path)
+    cfg = make_config(
+        tmp_path,
+        category_queries=[
+            {"fields": ["genres"], "values_query_template_file": str(facet)},
+            {"fields": ["genres"], "values": ["fallback"],
+             "query_text_template_file": str(template)},
+        ],
+    )
+    ds = DataStore(path=tmp_path / "ds.json", ignore_saved_data=True)
+    engine = ValueDiscoveryEngine(values_by_field={"genres": []})
+
+    with caplog.at_level("WARNING"):
+        add_category_queries(cfg, ds, engine)
+
+    warnings = [r for r in caplog.records if "no values" in r.getMessage()]
+    assert len(warnings) == 1
+    assert "field='genres'" in warnings[0].getMessage()
+    assert any(q.text == "fallback movies" for q in ds.get_queries())
+
+
+def test_add_category_queries__explicit_values_short_circuit_does_not_call_engine(tmp_path):
+    cfg = make_config(
+        tmp_path,
+        category_queries=[
+            {"fields": ["genres"], "values": ["comedy"]},
+        ],
+    )
+    ds = DataStore(path=tmp_path / "ds.json", ignore_saved_data=True)
+    engine = FakeSearchEngine([])
+
+    add_category_queries(cfg, ds, engine)
+
+    assert [q.text for q in ds.get_queries()] == ["comedy"]
+
+
+def test_add_category_queries__rendered_duplicates_dedupe(tmp_path):
+    template = genre_query_template(tmp_path)
+    cfg = make_config(
+        tmp_path,
+        category_queries=[
+            {"fields": ["genres"], "values": ["comedy", "comedy "],
+             "query_text_template_file": str(template)},
+        ],
+    )
+    ds = DataStore(path=tmp_path / "ds.json", ignore_saved_data=True)
+    engine = FakeSearchEngine([])
+
+    add_category_queries(cfg, ds, engine)
+
+    assert len(ds.get_queries()) == 1

--- a/tests/llm_search_quality_evaluation/dataset_generator/test_config_category_queries.py
+++ b/tests/llm_search_quality_evaluation/dataset_generator/test_config_category_queries.py
@@ -1,0 +1,389 @@
+from pathlib import Path
+
+import pytest
+from pydantic_core import ValidationError
+
+from llm_search_quality_evaluation.dataset_generator.config import Config
+
+
+def _base_cfg_kwargs(tmp_path: Path) -> dict:
+    """Minimal kwargs for a valid Config; tests override what they need."""
+    llm_cfg = tmp_path / "llm_cfg.yaml"
+    llm_cfg.write_text("name: mock\nmodel: mock-model\nmax_tokens: 16\n", encoding="utf-8")
+    return dict(
+        query_template=None,
+        search_engine_type="solr",
+        collection_name="testcore",
+        search_engine_url="http://localhost:8983/solr/",
+        documents_filter=None,
+        number_of_docs=1,
+        doc_fields=["title", "genres"],
+        queries=None,
+        generate_queries_from_documents=True,
+        num_queries_needed=1,
+        relevance_scale="graded",
+        llm_configuration_file=llm_cfg,
+        output_format="quepid",
+        output_destination=tmp_path,
+        save_llm_explanation=False,
+        llm_explanation_destination=None,
+        id_field=None,
+        rre_query_template=None,
+        rre_query_placeholder=None,
+        verbose=False,
+        datastore_autosave_every_n_updates=None,
+        enable_cartesian_product=False,
+    )
+
+
+def _write_template(tmp_path: Path, content: str = "$query movies\n") -> Path:
+    template = tmp_path / "genre_query.tmpl"
+    template.write_text(content, encoding="utf-8")
+    return template
+
+
+def test_category_queries__valid_config_renders_expected_query_strings(tmp_path):
+    template = _write_template(tmp_path)
+    cfg = Config(
+        **_base_cfg_kwargs(tmp_path),
+        category_queries=[
+            {"fields": ["genres"], "values": ["comedy", "action"], "query_text_template_file": str(template)},
+        ],
+    )
+
+    source = cfg.category_queries[0]
+    raw = source.query_text_template_file.read_text(encoding="utf-8").strip()
+    rendered = [raw.replace(cfg.category_query_placeholder, v) for v in source.values]
+    assert rendered == ["comedy movies", "action movies"]
+
+
+def test_category_queries__vespa_uses_at_kw_placeholder(tmp_path):
+    template = _write_template(tmp_path, content="@kw movies\n")
+    base = _base_cfg_kwargs(tmp_path)
+    base["search_engine_type"] = "vespa"
+    base["search_engine_url"] = "http://localhost:8080/search/"
+    base["query_template"] = None
+    cfg = Config(
+        **base,
+        category_queries=[
+            {"fields": ["genres"], "values": ["comedy"], "query_text_template_file": str(template)},
+        ],
+    )
+    assert cfg.category_query_placeholder == "@kw"
+
+
+def test_category_queries__vespa_template_with_dollar_query_fails_validation(tmp_path):
+    """Sanity: a Vespa-engine config rejects a template that uses $query (Solr convention)."""
+    template = _write_template(tmp_path, content="$query movies\n")
+    base = _base_cfg_kwargs(tmp_path)
+    base["search_engine_type"] = "vespa"
+    base["search_engine_url"] = "http://localhost:8080/search/"
+    base["query_template"] = None
+    with pytest.raises(ValidationError, match="@kw"):
+        Config(
+            **base,
+            category_queries=[
+                {"fields": ["genres"], "values": ["comedy"], "query_text_template_file": str(template)},
+            ],
+        )
+
+
+def test_category_queries__missing_template_file_fails_validation(tmp_path):
+    with pytest.raises(ValidationError):
+        Config(
+            **_base_cfg_kwargs(tmp_path),
+            category_queries=[
+                {"fields": ["genres"], "values": ["comedy"], "query_text_template_file": str(tmp_path / "nope.tmpl")},
+            ],
+        )
+
+
+def test_category_queries__template_without_placeholder_fails_validation(tmp_path):
+    template = _write_template(tmp_path, content="just movies\n")
+    with pytest.raises(ValidationError):
+        Config(
+            **_base_cfg_kwargs(tmp_path),
+            category_queries=[
+                {"fields": ["genres"], "values": ["comedy"], "query_text_template_file": str(template)},
+            ],
+        )
+
+
+def test_category_queries__empty_string_in_fields_fails_validation(tmp_path):
+    template = _write_template(tmp_path)
+    with pytest.raises(ValidationError):
+        Config(
+            **_base_cfg_kwargs(tmp_path),
+            category_queries=[
+                {"fields": [" "], "values": ["comedy"], "query_text_template_file": str(template)},
+            ],
+        )
+
+
+def test_category_queries__empty_string_in_values_fails_validation(tmp_path):
+    template = _write_template(tmp_path)
+    with pytest.raises(ValidationError):
+        Config(
+            **_base_cfg_kwargs(tmp_path),
+            category_queries=[
+                {"fields": ["genres"], "values": [""], "query_text_template_file": str(template)},
+            ],
+        )
+
+
+def test_category_queries__multiple_fields_rejected(tmp_path):
+    template = _write_template(tmp_path)
+    with pytest.raises(ValidationError, match="not yet supported"):
+        Config(
+            **_base_cfg_kwargs(tmp_path),
+            category_queries=[
+                {
+                    "fields": ["genres", "sub_genres"],
+                    "values": ["comedy"],
+                    "query_text_template_file": str(template),
+                },
+            ],
+        )
+
+
+def test_category_queries__field_not_in_doc_fields_fails_validation(tmp_path):
+    template = _write_template(tmp_path)
+    base = _base_cfg_kwargs(tmp_path)
+    base["doc_fields"] = ["title"]  # 'genres' is missing
+    with pytest.raises(ValidationError, match="doc_fields"):
+        Config(
+            **base,
+            category_queries=[
+                {"fields": ["genres"], "values": ["comedy"], "query_text_template_file": str(template)},
+            ],
+        )
+
+
+def test_category_queries__omitted_defaults_to_none(tmp_path):
+    cfg = Config(**_base_cfg_kwargs(tmp_path))
+    assert cfg.category_queries is None
+
+
+def test_category_queries__template_omitted_uses_bare_values(tmp_path):
+    """`query_text_template_file` is optional; without it, each value is the query text directly."""
+    cfg = Config(
+        **_base_cfg_kwargs(tmp_path),
+        category_queries=[
+            {"fields": ["genres"], "values": ["comedy", "action"]},
+        ],
+    )
+    assert cfg.category_queries[0].query_text_template_file is None
+
+
+def test_category_queries__same_path_as_query_template_fails_validation(tmp_path):
+    """Pointing query_text_template_file at the engine retrieval template (e.g. a YQL or Solr
+    JSON file) is the most common misuse — substitution would dump the engine payload as the
+    query string. Reject it explicitly with a clear error."""
+    shared = tmp_path / "query_template.yql"
+    shared.write_text("select * from movie where userInput($query) LIMIT 2\n", encoding="utf-8")
+    base = _base_cfg_kwargs(tmp_path)
+    base["query_template"] = str(shared)
+    with pytest.raises(ValidationError, match="same file as the engine retrieval"):
+        Config(
+            **base,
+            category_queries=[
+                {"fields": ["genres"], "values": ["comedy"], "query_text_template_file": str(shared)},
+            ],
+        )
+
+
+def test_category_queries__same_path_as_rre_query_template_fails_validation(tmp_path):
+    shared = tmp_path / "rre_query.json"
+    shared.write_text('{"q": "$query"}\n', encoding="utf-8")
+    base = _base_cfg_kwargs(tmp_path)
+    base["query_template"] = None
+    base["rre_query_template"] = str(shared)
+    with pytest.raises(ValidationError, match="same file as the engine retrieval"):
+        Config(
+            **base,
+            category_queries=[
+                {"fields": ["genres"], "values": ["comedy"], "query_text_template_file": str(shared)},
+            ],
+        )
+
+
+def test_generate_queries_from_documents__omitted_defaults_to_true(tmp_path):
+    base = _base_cfg_kwargs(tmp_path)
+    base.pop("generate_queries_from_documents")
+    cfg = Config(**base)
+    assert cfg.generate_queries_from_documents is True
+
+
+def test_generate_queries_from_documents__explicit_false_is_respected(tmp_path):
+    base = _base_cfg_kwargs(tmp_path)
+    base["generate_queries_from_documents"] = False
+    cfg = Config(**base)
+    assert cfg.generate_queries_from_documents is False
+
+
+def _write_solr_facet_template(tmp_path: Path) -> Path:
+    p = tmp_path / "genre_facet_solr.json"
+    p.write_text(
+        '{"q": "*:*", "facet": "true", "facet.field": "genres", "facet.limit": 100, "rows": 0}\n',
+        encoding="utf-8",
+    )
+    return p
+
+
+def test_category_queries__values_and_values_query_template_file_both_set_fails(tmp_path):
+    facet = _write_solr_facet_template(tmp_path)
+    with pytest.raises(ValidationError, match="exactly one"):
+        Config(
+            **_base_cfg_kwargs(tmp_path),
+            category_queries=[
+                {"fields": ["genres"], "values": ["comedy"], "values_query_template_file": str(facet)},
+            ],
+        )
+
+
+def test_category_queries__neither_values_nor_values_query_template_file_fails(tmp_path):
+    with pytest.raises(ValidationError, match="exactly one"):
+        Config(
+            **_base_cfg_kwargs(tmp_path),
+            category_queries=[
+                {"fields": ["genres"]},
+            ],
+        )
+
+
+def test_category_queries__values_null_with_values_query_template_file_passes(tmp_path):
+    facet = _write_solr_facet_template(tmp_path)
+    cfg = Config(
+        **_base_cfg_kwargs(tmp_path),
+        category_queries=[
+            {"fields": ["genres"], "values": None, "values_query_template_file": str(facet)},
+        ],
+    )
+    assert cfg.category_queries[0].values is None
+    assert cfg.category_queries[0].values_query_template_file is not None
+
+
+def test_category_queries__values_null_and_values_query_template_file_null_fails(tmp_path):
+    with pytest.raises(ValidationError, match="exactly one"):
+        Config(
+            **_base_cfg_kwargs(tmp_path),
+            category_queries=[
+                {"fields": ["genres"], "values": None, "values_query_template_file": None},
+            ],
+        )
+
+
+def test_category_queries__values_query_template_file_at_query_template_path_fails(tmp_path):
+    """values_query_template_file pointing at top-level query_template (engine retrieval payload)."""
+    shared = tmp_path / "query_template.json"
+    shared.write_text('{"q": "$query"}\n', encoding="utf-8")
+    base = _base_cfg_kwargs(tmp_path)
+    base["query_template"] = str(shared)
+    with pytest.raises(ValidationError, match="value-discovery"):
+        Config(
+            **base,
+            category_queries=[
+                {"fields": ["genres"], "values_query_template_file": str(shared)},
+            ],
+        )
+
+
+def test_category_queries__values_query_template_file_at_rre_query_template_path_fails(tmp_path):
+    shared = tmp_path / "rre_query.json"
+    shared.write_text('{"q": "$query"}\n', encoding="utf-8")
+    base = _base_cfg_kwargs(tmp_path)
+    base["query_template"] = None
+    base["rre_query_template"] = str(shared)
+    with pytest.raises(ValidationError, match="value-discovery"):
+        Config(
+            **base,
+            category_queries=[
+                {"fields": ["genres"], "values_query_template_file": str(shared)},
+            ],
+        )
+
+
+def test_category_queries__values_query_template_file_same_as_query_text_template_file_fails(tmp_path):
+    """Three-way collision check: values_query_template_file must not equal
+    query_text_template_file on the same source."""
+    shared = tmp_path / "shared.json"
+    shared.write_text('{"q": "*:*"}\n', encoding="utf-8")
+    with pytest.raises(ValidationError, match="different concepts"):
+        Config(
+            **_base_cfg_kwargs(tmp_path),
+            category_queries=[
+                {
+                    "fields": ["genres"],
+                    "values_query_template_file": str(shared),
+                    "query_text_template_file": str(shared),
+                },
+            ],
+        )
+
+
+def test_category_queries__values_query_template_file_missing_path_fails(tmp_path):
+    with pytest.raises(ValidationError):
+        Config(
+            **_base_cfg_kwargs(tmp_path),
+            category_queries=[
+                {"fields": ["genres"], "values_query_template_file": str(tmp_path / "nope.json")},
+            ],
+        )
+
+
+def test_check_no_empty_values__accepts_none_after_values_made_optional(tmp_path):
+    """Regression: when values is `None` (engine-discovery mode) the field validator must not crash."""
+    facet = _write_solr_facet_template(tmp_path)
+    # If `check_no_empty_values` doesn't accept None, this would raise during model construction.
+    Config(
+        **_base_cfg_kwargs(tmp_path),
+        category_queries=[
+            {"fields": ["genres"], "values_query_template_file": str(facet)},
+        ],
+    )
+
+
+def test_path_collision_validator_runs_before_placeholder_content_validator(tmp_path):
+    """Pointing query_text_template_file at a value-discovery JSON file must produce the
+    informative 'different concepts' error, not a misleading 'missing placeholder' one.
+
+    Without correct validator ordering, placeholder validation runs first and complains that
+    the JSON file is missing `$query`, masking the actual mistake.
+    """
+    shared = tmp_path / "shared.json"
+    shared.write_text('{"q": "*:*"}\n', encoding="utf-8")
+    with pytest.raises(ValidationError) as exc:
+        Config(
+            **_base_cfg_kwargs(tmp_path),
+            category_queries=[
+                {
+                    "fields": ["genres"],
+                    "values_query_template_file": str(shared),
+                    "query_text_template_file": str(shared),
+                },
+            ],
+        )
+    msg = str(exc.value)
+    assert "different concepts" in msg
+    assert "must contain the literal placeholder" not in msg
+
+
+def test_generate_queries_from_documents__null_fails_validation(tmp_path):
+    cfg_text = (
+        'search_engine_type: "solr"\n'
+        'collection_name: "testcore"\n'
+        'search_engine_url: "http://localhost:8983/solr/"\n'
+        'number_of_docs: 1\n'
+        'doc_fields: ["title"]\n'
+        'num_queries_needed: 1\n'
+        'relevance_scale: "graded"\n'
+        'llm_configuration_file: "tests/resources/llm_config.yaml"\n'
+        'output_format: "quepid"\n'
+        'output_destination: "output"\n'
+        'generate_queries_from_documents: null\n'
+    )
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text(cfg_text, encoding="utf-8")
+
+    with pytest.raises(ValidationError):
+        Config.load(str(cfg_path))

--- a/tests/llm_search_quality_evaluation/dataset_generator/test_config_dataset_generator.py
+++ b/tests/llm_search_quality_evaluation/dataset_generator/test_config_dataset_generator.py
@@ -77,6 +77,29 @@ def test_mteb_config__expects__successful_load(resource_folder):
     assert mteb_config.output_format == "mteb"
     assert mteb_config.output_destination == Path("output")
 
+
+def test_vespa_config_without_schema__expects__schema_defaults_to_collection_name(tmp_path):
+    cfg_text = (
+        "search_engine_type: \"vespa\"\n"
+        "collection_name: \"movie\"\n"
+        "search_engine_url: \"http://localhost:8080/search/\"\n"
+        "number_of_docs: 2\n"
+        "doc_fields: [\"title\"]\n"
+        "num_queries_needed: 2\n"
+        "relevance_scale: \"binary\"\n"
+        "llm_configuration_file: \"tests/resources/llm_config.yaml\"\n"
+        "output_format: \"quepid\"\n"
+        "output_destination: \"output\"\n"
+    )
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text(cfg_text, encoding="utf-8")
+
+    cfg = Config.load(str(cfg_path))
+
+    assert cfg.vespa_schema == "movie"
+    assert cfg.search_engine_collection_endpoint == HttpUrl("http://localhost:8080/search/movie/")
+
+
 def test_missing_both_templates_with_rre__expects__raises_validation_error(resource_folder):
     file_name = "missing_both_templates.yaml"
     with pytest.raises(ValidationError):
@@ -103,6 +126,132 @@ def test_autosave_valid_positive_int__expects__parsed(tmp_path):
 
     cfg = Config.load(str(cfg_path))
     assert cfg.datastore_autosave_every_n_updates == 50
+
+
+_MIN_VALID_CFG = (
+    "search_engine_type: \"solr\"\n"
+    "collection_name: \"testcore\"\n"
+    "search_engine_url: \"http://localhost:8983/solr/\"\n"
+    "number_of_docs: 2\n"
+    "doc_fields: [\"title\"]\n"
+    "num_queries_needed: 2\n"
+    "relevance_scale: \"binary\"\n"
+    "llm_configuration_file: \"tests/resources/llm_config.yaml\"\n"
+    "output_format: \"quepid\"\n"
+    "output_destination: \"output\"\n"
+)
+
+
+def _write_cfg_with(tmp_path, extra_yaml: str):
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text(_MIN_VALID_CFG + extra_yaml, encoding="utf-8")
+    return cfg_path
+
+
+def test_default_llm_micro_batch_size__expects__one(tmp_path):
+    cfg = Config.load(str(_write_cfg_with(tmp_path, "")))
+    assert cfg.llm_micro_batch_size == 1
+
+
+def test_default_llm_batch_max_retries__expects__three(tmp_path):
+    cfg = Config.load(str(_write_cfg_with(tmp_path, "")))
+    assert cfg.llm_batch_max_retries == 3
+
+
+def test_default_llm_batch_score_prompt__expects__none(tmp_path):
+    cfg = Config.load(str(_write_cfg_with(tmp_path, "")))
+    assert cfg.llm_batch_score_prompt is None
+
+
+def test_default_llm_max_workers__expects__one(tmp_path):
+    cfg = Config.load(str(_write_cfg_with(tmp_path, "")))
+    assert cfg.llm_max_workers == 1
+
+
+def test_llm_max_workers_zero__expects__raises_validation_error(tmp_path):
+    cfg_path = _write_cfg_with(tmp_path, "llm_max_workers: 0\n")
+    with pytest.raises(ValidationError):
+        Config.load(str(cfg_path))
+
+
+def test_llm_max_workers_positive__expects__parsed(tmp_path):
+    cfg_path = _write_cfg_with(tmp_path, "llm_max_workers: 4\n")
+    cfg = Config.load(str(cfg_path))
+    assert cfg.llm_max_workers == 4
+
+
+def test_llm_micro_batch_size_zero__expects__raises_validation_error(tmp_path):
+    cfg_path = _write_cfg_with(tmp_path, "llm_micro_batch_size: 0\n")
+    with pytest.raises(ValidationError):
+        Config.load(str(cfg_path))
+
+
+def test_llm_batch_max_retries_negative__expects__raises_validation_error(tmp_path):
+    cfg_path = _write_cfg_with(tmp_path, "llm_batch_max_retries: -1\n")
+    with pytest.raises(ValidationError):
+        Config.load(str(cfg_path))
+
+
+def test_valid_batch_prompt_template__expects__loads(tmp_path):
+    prompt = tmp_path / "batch_prompt.txt"
+    prompt.write_text(
+        "Score the docs on {relevance_scale} for query '{query}'.\n"
+        "Documents:\n{documents_json}\n",
+        encoding="utf-8",
+    )
+    cfg_path = _write_cfg_with(tmp_path, f"llm_batch_score_prompt: \"{prompt}\"\n")
+    cfg = Config.load(str(cfg_path))
+    assert cfg.llm_batch_score_prompt == prompt
+
+
+def test_batch_prompt_missing_required_placeholder__expects__raises_validation_error(tmp_path):
+    # No {documents_json} placeholder.
+    prompt = tmp_path / "bad_prompt.txt"
+    prompt.write_text("Query: {query}, scale: {relevance_scale}\n", encoding="utf-8")
+    cfg_path = _write_cfg_with(tmp_path, f"llm_batch_score_prompt: \"{prompt}\"\n")
+    with pytest.raises(ValidationError, match=r"required placeholder"):
+        Config.load(str(cfg_path))
+
+
+def test_batch_prompt_unknown_placeholder__expects__raises_validation_error(tmp_path):
+    # Typo: {documents} instead of {documents_json}.
+    prompt = tmp_path / "bad_prompt.txt"
+    prompt.write_text(
+        "Query: {query}\nDocs: {documents}\nScale: {relevance_scale}\n",
+        encoding="utf-8",
+    )
+    cfg_path = _write_cfg_with(tmp_path, f"llm_batch_score_prompt: \"{prompt}\"\n")
+    with pytest.raises(ValidationError, match=r"unsupported placeholder"):
+        Config.load(str(cfg_path))
+
+
+def test_batch_prompt_unescaped_json_braces__expects__raises_validation_error(tmp_path):
+    # Unescaped JSON example in the template body — classic str.format footgun.
+    prompt = tmp_path / "bad_prompt.txt"
+    prompt.write_text(
+        "Query: {query}\n"
+        "Docs (example): {\"id\": 1}\n"
+        "Real docs: {documents_json}\n"
+        "Scale: {relevance_scale}\n",
+        encoding="utf-8",
+    )
+    cfg_path = _write_cfg_with(tmp_path, f"llm_batch_score_prompt: \"{prompt}\"\n")
+    with pytest.raises(ValidationError):
+        Config.load(str(cfg_path))
+
+
+def test_batch_prompt_validated_even_when_batch_size_is_one(tmp_path):
+    # The user runs at size=1 today; the broken prompt must still fail at config load
+    # so flipping to size=10 tomorrow doesn't blow up at runtime.
+    prompt = tmp_path / "bad_prompt.txt"
+    prompt.write_text("Only {query}\n", encoding="utf-8")
+    cfg_path = _write_cfg_with(
+        tmp_path,
+        "llm_micro_batch_size: 1\n"
+        f"llm_batch_score_prompt: \"{prompt}\"\n",
+    )
+    with pytest.raises(ValidationError):
+        Config.load(str(cfg_path))
 
 
 def test_autosave_invalid_non_positive__expects__raises_validation_error(tmp_path):

--- a/tests/llm_search_quality_evaluation/dataset_generator/test_main_autosave.py
+++ b/tests/llm_search_quality_evaluation/dataset_generator/test_main_autosave.py
@@ -44,6 +44,7 @@ max_tokens: 16
         rre_query_placeholder=None,
         verbose=False,
         datastore_autosave_every_n_updates=7,
+        enable_cartesian_product=False,
     )
 
     # Patch Config.load to return our in-memory cfg (bypass reading from disk)
@@ -58,8 +59,9 @@ max_tokens: 16
     monkeypatch.setattr(main_mod, "LLMServiceFactory", types.SimpleNamespace(build_lazy=lambda _cfg: object()))
     monkeypatch.setattr(main_mod, "WriterFactory", types.SimpleNamespace(build=lambda _cfg: DummyWriter()))
 
-    # No-op the heavy flow functions to keep the test focused on wiring
-    monkeypatch.setattr(main_mod, "generate_and_add_queries", lambda *args, **kwargs: None)
+    # With both `generate_queries_from_documents=False` and `enable_cartesian_product=False`,
+    # seed-fetch and LLM-gen paths are gated off; top-K is short-circuited by `query_template=None`.
+    # Defensive no-ops kept for the remaining flow functions in case gating changes in the future.
     monkeypatch.setattr(main_mod, "add_cartesian_product_scores", lambda *args, **kwargs: None)
     monkeypatch.setattr(main_mod, "expand_docset_with_search_engine_top_k", lambda *args, **kwargs: None)
 

--- a/tests/llm_search_quality_evaluation/dataset_generator/test_main_category_wiring.py
+++ b/tests/llm_search_quality_evaluation/dataset_generator/test_main_category_wiring.py
@@ -1,0 +1,220 @@
+from llm_search_quality_evaluation.dataset_generator import main as main_mod
+from llm_search_quality_evaluation.shared.data_store import DataStore
+from llm_search_quality_evaluation.shared.models import Document
+
+from category_query_test_utils import (
+    FakeLLMService,
+    FakeSearchEngine,
+    genre_query_template,
+    make_config,
+    patch_main_dependencies,
+)
+
+
+def test_main__category_only_skips_llm_gen_and_still_fetches_seeds_for_cartesian(tmp_path, monkeypatch):
+    template = genre_query_template(tmp_path)
+    cfg = make_config(
+        tmp_path,
+        generate_queries_from_documents=False,
+        enable_cartesian_product=True,
+        category_queries=[
+            {"fields": ["genres"], "values": ["comedy"], "query_text_template_file": str(template)},
+        ],
+    )
+
+    seed_doc = Document(id="d1", fields={"title": "Some movie", "genres": ["comedy"]})
+    engine = FakeSearchEngine([seed_doc])
+    llm = FakeLLMService()
+
+    patch_main_dependencies(monkeypatch, cfg, engine, llm)
+
+    captured = {}
+
+    class _DataStoreCapture(DataStore):
+        def __init__(self, *a, **kw):
+            super().__init__(path=tmp_path / "ds.json", ignore_saved_data=True,
+                             autosave_every_n_updates=kw.get("autosave_every_n_updates"))
+            captured["ds"] = self
+
+    monkeypatch.setattr(main_mod, "DataStore", _DataStoreCapture)
+
+    main_mod.main()
+
+    ds = captured["ds"]
+    assert any(q.text == "comedy movies" for q in ds.get_queries())
+    assert engine.fetch_calls == 1
+    assert "d1" in {d.id for d in ds.get_cartesian_prod_docs()}
+    assert llm.generate_queries_calls == []
+
+
+def test_main__engine_discovery_with_cartesian_produces_ratings(tmp_path, monkeypatch):
+    facet = tmp_path / "facet_solr.json"
+    facet.write_text('{"q": "*:*", "facet": "true", "facet.field": "genres", "rows": 0}\n', encoding="utf-8")
+    template = genre_query_template(tmp_path)
+    cfg = make_config(
+        tmp_path,
+        generate_queries_from_documents=False,
+        enable_cartesian_product=True,
+        category_queries=[
+            {"fields": ["genres"], "values_query_template_file": str(facet),
+             "query_text_template_file": str(template)},
+        ],
+    )
+
+    seed_doc = Document(id="d1", fields={"title": "Some movie", "genres": ["comedy"]})
+
+    class _DiscoveryEngine:
+        def __init__(self):
+            self.fetch_calls = 0
+            self.value_calls = 0
+
+        def fetch_for_query_generation(self, documents_filter, number_of_docs, doc_fields):
+            self.fetch_calls += 1
+            return [seed_doc]
+
+        def fetch_field_values(self, values_query_template, field):
+            self.value_calls += 1
+            return ["comedy"]
+
+    engine = _DiscoveryEngine()
+    llm = FakeLLMService(score=2)
+
+    patch_main_dependencies(monkeypatch, cfg, engine, llm, stub_cartesian=False)
+
+    captured = {}
+
+    class _DataStoreCapture(DataStore):
+        def __init__(self, *a, **kw):
+            super().__init__(path=tmp_path / "ds.json", ignore_saved_data=True,
+                             autosave_every_n_updates=kw.get("autosave_every_n_updates"))
+            captured["ds"] = self
+
+    monkeypatch.setattr(main_mod, "DataStore", _DataStoreCapture)
+
+    main_mod.main()
+
+    ds = captured["ds"]
+    category_query = next(q for q in ds.get_queries() if q.text == "comedy movies")
+
+    assert engine.value_calls == 1
+    assert engine.fetch_calls == 1
+    assert llm.generate_score_calls == [("d1", "comedy movies")]
+    rating = ds.rating_by_pair.get((category_query.id, "d1"))
+    assert rating is not None
+    assert rating.score == 2
+
+
+def test_main__category_query_rated_against_seed_doc_via_cartesian(tmp_path, monkeypatch):
+    template = genre_query_template(tmp_path)
+    cfg = make_config(
+        tmp_path,
+        generate_queries_from_documents=False,
+        enable_cartesian_product=True,
+        category_queries=[
+            {"fields": ["genres"], "values": ["comedy"], "query_text_template_file": str(template)},
+        ],
+    )
+
+    seed_doc = Document(id="d1", fields={"title": "Some movie", "genres": ["comedy"]})
+    engine = FakeSearchEngine([seed_doc])
+    llm = FakeLLMService(score=2)
+
+    patch_main_dependencies(monkeypatch, cfg, engine, llm, stub_cartesian=False)
+
+    captured = {}
+
+    class _DataStoreCapture(DataStore):
+        def __init__(self, *a, **kw):
+            super().__init__(path=tmp_path / "ds.json", ignore_saved_data=True,
+                             autosave_every_n_updates=kw.get("autosave_every_n_updates"))
+            captured["ds"] = self
+
+    monkeypatch.setattr(main_mod, "DataStore", _DataStoreCapture)
+
+    main_mod.main()
+
+    ds = captured["ds"]
+    category_query = next(q for q in ds.get_queries() if q.text == "comedy movies")
+
+    assert llm.generate_score_calls == [("d1", "comedy movies")]
+    rating = ds.rating_by_pair.get((category_query.id, "d1"))
+    assert rating is not None
+    assert rating.score == 2
+
+
+def test_main__both_flags_off_does_not_call_search_engine(tmp_path, monkeypatch):
+    cfg = make_config(
+        tmp_path,
+        generate_queries_from_documents=False,
+        enable_cartesian_product=False,
+    )
+
+    engine = FakeSearchEngine([Document(id="d1", fields={"title": "t"})])
+    llm = FakeLLMService()
+
+    patch_main_dependencies(monkeypatch, cfg, engine, llm)
+    monkeypatch.setattr(main_mod, "DataStore",
+                        lambda **kw: DataStore(path=tmp_path / "ds.json", ignore_saved_data=True,
+                                               autosave_every_n_updates=kw.get("autosave_every_n_updates")))
+
+    main_mod.main()
+
+    assert engine.fetch_calls == 0
+    assert llm.generate_queries_calls == []
+
+
+def test_main__llm_gen_reuses_seed_docs_no_double_fetch(tmp_path, monkeypatch):
+    template = genre_query_template(tmp_path)
+    cfg = make_config(
+        tmp_path,
+        generate_queries_from_documents=True,
+        enable_cartesian_product=True,
+        category_queries=[
+            {"fields": ["genres"], "values": ["comedy"], "query_text_template_file": str(template)},
+        ],
+        num_queries_needed=10,
+        number_of_docs=1,
+    )
+
+    seed = Document(id="d1", fields={"title": "Some movie", "genres": ["comedy"]})
+    engine = FakeSearchEngine([seed])
+    llm = FakeLLMService(queries_per_doc={"d1": ["q-from-doc"]})
+
+    patch_main_dependencies(monkeypatch, cfg, engine, llm)
+    monkeypatch.setattr(main_mod, "DataStore",
+                        lambda **kw: DataStore(path=tmp_path / "ds.json", ignore_saved_data=True,
+                                               autosave_every_n_updates=kw.get("autosave_every_n_updates")))
+
+    main_mod.main()
+
+    assert engine.fetch_calls == 1
+    assert llm.generate_queries_calls == ["d1"]
+
+
+def test_main__category_fills_budget_then_llm_gen_skipped(tmp_path, monkeypatch):
+    template = genre_query_template(tmp_path)
+    cfg = make_config(
+        tmp_path,
+        generate_queries_from_documents=True,
+        enable_cartesian_product=True,
+        category_queries=[
+            {"fields": ["genres"],
+             "values": ["comedy", "action", "horror"],
+             "query_text_template_file": str(template)},
+        ],
+        num_queries_needed=2,
+        number_of_docs=1,
+    )
+
+    engine = FakeSearchEngine([Document(id="d1", fields={"title": "t", "genres": ["comedy"]})])
+    llm = FakeLLMService(queries_per_doc={"d1": ["should-not-be-added"]})
+
+    patch_main_dependencies(monkeypatch, cfg, engine, llm)
+    monkeypatch.setattr(main_mod, "DataStore",
+                        lambda **kw: DataStore(path=tmp_path / "ds.json", ignore_saved_data=True,
+                                               autosave_every_n_updates=kw.get("autosave_every_n_updates")))
+
+    main_mod.main()
+
+    assert engine.fetch_calls == 1
+    assert llm.generate_queries_calls == []

--- a/tests/llm_search_quality_evaluation/dataset_generator/test_main_parallel_query_gen.py
+++ b/tests/llm_search_quality_evaluation/dataset_generator/test_main_parallel_query_gen.py
@@ -1,0 +1,173 @@
+"""Tests for parallel query generation from seed documents.
+
+Exercises ``generate_and_add_queries_from_documents`` at ``llm_max_workers > 1``.
+
+Key invariants:
+- Worker LLM calls overlap (peak in-flight > 1).
+- Results are *applied* on the main thread in seed-doc order — so the stored
+  query set, source labels, pre-rating linkage, and budget cutoff are identical
+  to the sequential path for the same fake responses.
+- Outer/inner budget guards still kick in.
+"""
+from __future__ import annotations
+
+import threading
+import time
+from types import SimpleNamespace
+from typing import Dict, List
+
+from llm_search_quality_evaluation.dataset_generator.main import generate_and_add_queries_from_documents
+from llm_search_quality_evaluation.shared.data_store import DataStore
+from llm_search_quality_evaluation.shared.models import Document
+
+
+def _config(**overrides):
+    """Minimal SimpleNamespace config — all paths through
+    ``generate_and_add_queries_from_documents`` only read the listed fields."""
+    values = {
+        "num_queries_needed": 10,
+        "number_of_docs": 4,
+        "max_query_terms": None,
+        "relevance_scale": "binary",
+        "relevance_label_set": {0, 1},
+        "llm_max_workers": 1,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+class _ConcurrencyTrackingQueryLLM:
+    """Fake LLMService.generate_queries that records peak in-flight calls."""
+
+    def __init__(self, queries_per_doc: Dict[str, List[str]], hold_seconds: float = 0.05):
+        self._queries_per_doc = queries_per_doc
+        self._hold = hold_seconds
+        self._lock = threading.Lock()
+        self._in_flight = 0
+        self.max_in_flight = 0
+        self.generate_queries_calls: List[str] = []
+
+    def generate_queries(self, doc: Document, num_queries_per_doc: int, max_query_terms):
+        with self._lock:
+            self._in_flight += 1
+            self.generate_queries_calls.append(doc.id)
+            if self._in_flight > self.max_in_flight:
+                self.max_in_flight = self._in_flight
+        try:
+            time.sleep(self._hold)
+        finally:
+            with self._lock:
+                self._in_flight -= 1
+        queries = self._queries_per_doc.get(doc.id, [f"q-from-{doc.id}"])
+        return SimpleNamespace(get_queries=lambda: list(queries))
+
+
+def test_query_gen__parallel_workers__overlap_in_flight():
+    ds = DataStore(ignore_saved_data=True)
+    seed_docs = [Document(id=f"d{i}", fields={"title": f"t{i}"}) for i in range(4)]
+    for d in seed_docs:
+        ds.add_document(d)
+
+    llm = _ConcurrencyTrackingQueryLLM(
+        queries_per_doc={f"d{i}": [f"query-from-d{i}"] for i in range(4)},
+        hold_seconds=0.05,
+    )
+
+    generate_and_add_queries_from_documents(
+        _config(llm_max_workers=4, num_queries_needed=10, number_of_docs=4),
+        ds, llm, seed_docs,
+    )
+
+    # All 4 calls fired; at least 2 overlapped under 4 workers.
+    assert len(llm.generate_queries_calls) == 4
+    assert llm.max_in_flight > 1
+
+
+def test_query_gen__parallel_workers__results_applied_in_seed_doc_order():
+    """Same fake responses + parallel run must produce the same stored queries,
+    in the same insertion order, as the sequential run. This is the contract
+    that 'apply in seed-doc order' protects."""
+    seed_docs = [Document(id=f"d{i}", fields={"title": f"t{i}"}) for i in range(3)]
+    responses = {
+        "d0": ["q-a", "q-b"],
+        "d1": ["q-c", "q-d"],
+        "d2": ["q-e", "q-f"],
+    }
+
+    def run(max_workers: int) -> List[str]:
+        ds = DataStore(ignore_saved_data=True)
+        for d in seed_docs:
+            ds.add_document(d)
+        # Slow workers so threading actually scrambles completion order in the
+        # parallel run; the apply-in-seed-order contract should still hold.
+        llm = _ConcurrencyTrackingQueryLLM(
+            queries_per_doc=responses,
+            hold_seconds=0.04 if max_workers > 1 else 0.0,
+        )
+        generate_and_add_queries_from_documents(
+            _config(llm_max_workers=max_workers, num_queries_needed=10, number_of_docs=3),
+            ds, llm, seed_docs,
+        )
+        return [q.text for q in ds.get_queries()]
+
+    sequential = run(1)
+    parallel = run(4)
+
+    assert sequential == ["q-a", "q-b", "q-c", "q-d", "q-e", "q-f"]
+    assert parallel == sequential
+
+
+def test_query_gen__parallel_workers__pre_rating_tied_to_source_seed_doc():
+    """Each generated query must be pre-rated against the seed doc it was
+    generated from — not some other doc that happened to finish concurrently."""
+    seed_docs = [Document(id=f"d{i}", fields={"title": f"t{i}"}) for i in range(3)]
+    responses = {
+        "d0": ["q-from-d0"],
+        "d1": ["q-from-d1"],
+        "d2": ["q-from-d2"],
+    }
+
+    ds = DataStore(ignore_saved_data=True)
+    for d in seed_docs:
+        ds.add_document(d)
+
+    llm = _ConcurrencyTrackingQueryLLM(queries_per_doc=responses, hold_seconds=0.03)
+    generate_and_add_queries_from_documents(
+        _config(llm_max_workers=4, num_queries_needed=10, number_of_docs=3),
+        ds, llm, seed_docs,
+    )
+
+    text_by_id = {q.id: q.text for q in ds.get_queries()}
+    for r in ds.get_ratings():
+        # Each rating's query text encodes the seed doc id it came from.
+        assert text_by_id[r.query_id] == f"q-from-{r.doc_id}"
+        assert r.score == 1  # max of {0, 1}
+
+
+def test_query_gen__parallel_workers__outer_budget_guard_stops_applying():
+    """When earlier seed-doc responses fill the budget, later docs' responses
+    must NOT be applied. Note that, by design, the executor still runs the
+    in-flight submitted futures to completion — but their applications are
+    skipped, so the stored query set matches the sequential outer-guard path."""
+    seed_docs = [Document(id=f"d{i}", fields={"title": f"t{i}"}) for i in range(4)]
+    responses = {
+        "d0": ["q-d0-a", "q-d0-b"],   # fills the budget of 2 by itself
+        "d1": ["q-d1-a"],             # must not be applied
+        "d2": ["q-d2-a"],
+        "d3": ["q-d3-a"],
+    }
+
+    ds = DataStore(ignore_saved_data=True)
+    for d in seed_docs:
+        ds.add_document(d)
+
+    llm = _ConcurrencyTrackingQueryLLM(queries_per_doc=responses, hold_seconds=0.0)
+    generate_and_add_queries_from_documents(
+        _config(llm_max_workers=4, num_queries_needed=2, number_of_docs=4),
+        ds, llm, seed_docs,
+    )
+
+    stored_texts = {q.text for q in ds.get_queries()}
+    assert stored_texts == {"q-d0-a", "q-d0-b"}
+    # Each stored query is rated only against its own seed doc.
+    assert len(ds.get_ratings()) == 2

--- a/tests/llm_search_quality_evaluation/dataset_generator/test_main_parallel_scoring.py
+++ b/tests/llm_search_quality_evaluation/dataset_generator/test_main_parallel_scoring.py
@@ -1,0 +1,272 @@
+"""Tests for parallel relevance scoring.
+
+Exercises both ``add_cartesian_product_scores`` and ``expand_docset_with_search_engine_top_k``
+at ``llm_max_workers > 1`` to confirm:
+- workers really overlap on the LLM call (peak in-flight > 1);
+- results match the sequential path (set comparison — completion order differs
+  under threads);
+- a worker failure (``BatchScoringError``) propagates out of the executor.
+"""
+from __future__ import annotations
+
+import threading
+import time
+from types import SimpleNamespace
+from typing import Dict, List
+
+import pytest
+
+from llm_search_quality_evaluation.dataset_generator.llm import BatchScoringError
+from llm_search_quality_evaluation.dataset_generator.main import (
+    add_cartesian_product_scores,
+    expand_docset_with_search_engine_top_k,
+)
+from llm_search_quality_evaluation.dataset_generator.models import LLMScoreResponse
+from llm_search_quality_evaluation.shared.data_store import DataStore
+from llm_search_quality_evaluation.shared.models import Document
+
+
+def _config(**overrides):
+    values = {
+        "num_queries_needed": 100,
+        "query_template": "select * from test where userInput(@kw)",
+        "doc_fields": ["title"],
+        "relevance_scale": "binary",
+        "save_llm_explanation": False,
+        "llm_micro_batch_size": 1,
+        "llm_batch_max_retries": 3,
+        "llm_batch_score_prompt": None,
+        "llm_max_workers": 1,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+class _ConcurrencyTrackingLLM:
+    """LLM fake that records max in-flight calls across threads.
+
+    Each call sleeps for ``hold_seconds`` so multiple threads can overlap.
+    """
+
+    def __init__(self, hold_seconds: float = 0.05):
+        self._hold = hold_seconds
+        self._lock = threading.Lock()
+        self._in_flight = 0
+        self.max_in_flight = 0
+        self.total_calls = 0
+
+    def _enter(self) -> None:
+        with self._lock:
+            self._in_flight += 1
+            self.total_calls += 1
+            if self._in_flight > self.max_in_flight:
+                self.max_in_flight = self._in_flight
+
+    def _exit(self) -> None:
+        with self._lock:
+            self._in_flight -= 1
+
+    def generate_score(self, document: Document, query: str, relevance_scale: str,
+                       explanation: bool = False) -> LLMScoreResponse:
+        self._enter()
+        try:
+            time.sleep(self._hold)
+        finally:
+            self._exit()
+        return LLMScoreResponse(score=1, scale=relevance_scale, explanation=None)
+
+    def generate_scores_batch(self, *, query_id, query_text, documents, relevance_scale,
+                              explanation, prompt_template, max_retries) -> Dict[str, LLMScoreResponse]:
+        self._enter()
+        try:
+            time.sleep(self._hold)
+        finally:
+            self._exit()
+        return {
+            d.id: LLMScoreResponse(score=1, scale=relevance_scale, explanation=None)
+            for d in documents
+        }
+
+
+class _FakeSearchEngine:
+    """Thread-safe fake; returns the same single doc per query."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self.queries: List[str] = []
+
+    def fetch_for_evaluation(self, keyword, query_template, doc_fields):
+        with self._lock:
+            self.queries.append(keyword)
+        return [Document(id=f"doc-{keyword}", fields={"title": keyword})]
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Scoring — top-K path
+# ─────────────────────────────────────────────────────────────────────
+def test_expand_topk__parallel_workers__overlap_in_flight():
+    """At llm_max_workers=4 with 4 queries and slow per-query calls,
+    peak concurrency should exceed 1."""
+    ds = DataStore(ignore_saved_data=True)
+    for q in ["q1", "q2", "q3", "q4"]:
+        ds.add_query(q)
+
+    llm = _ConcurrencyTrackingLLM(hold_seconds=0.05)
+    se = _FakeSearchEngine()
+
+    expand_docset_with_search_engine_top_k(
+        _config(llm_max_workers=4), ds, llm, se, prompt_template="ignored",
+    )
+
+    assert llm.total_calls == 4
+    assert llm.max_in_flight > 1, "expected overlap with 4 workers"
+
+
+def test_expand_topk__single_worker__no_overlap_matches_sequential():
+    """At llm_max_workers=1 the path is strictly sequential — peak in-flight == 1
+    and ratings written exactly match the sequential path."""
+    ds = DataStore(ignore_saved_data=True)
+    for q in ["q1", "q2", "q3"]:
+        ds.add_query(q)
+
+    llm = _ConcurrencyTrackingLLM(hold_seconds=0.01)
+    se = _FakeSearchEngine()
+
+    expand_docset_with_search_engine_top_k(
+        _config(llm_max_workers=1), ds, llm, se, prompt_template="ignored",
+    )
+
+    assert llm.max_in_flight == 1
+    # Sequential order is deterministic.
+    assert se.queries == ["q1", "q2", "q3"]
+    assert {r.doc_id for r in ds.get_ratings()} == {"doc-q1", "doc-q2", "doc-q3"}
+
+
+def test_expand_topk__parallel_workers__same_ratings_as_sequential():
+    """Same input + same fake LLM responses produce the same ratings set
+    regardless of llm_max_workers (set comparison; order is non-deterministic)."""
+    def run(max_workers: int):
+        ds = DataStore(ignore_saved_data=True)
+        for q in ["q1", "q2", "q3", "q4", "q5"]:
+            ds.add_query(q)
+        llm = _ConcurrencyTrackingLLM(hold_seconds=0.005)
+        se = _FakeSearchEngine()
+        expand_docset_with_search_engine_top_k(
+            _config(llm_max_workers=max_workers), ds, llm, se, prompt_template="ignored",
+        )
+        return {(r.query_id, r.doc_id, r.score) for r in ds.get_ratings()}, ds
+
+    sequential, ds_seq = run(1)
+    parallel, ds_par = run(4)
+
+    # Build a query-text → rating-set comparison so the two runs (with different
+    # randomly-generated query ids) can be compared by semantics.
+    def by_text(ds):
+        text_by_id = {q.id: q.text for q in ds.get_queries()}
+        return {(text_by_id[r.query_id], r.doc_id, r.score) for r in ds.get_ratings()}
+
+    assert by_text(ds_seq) == by_text(ds_par)
+
+
+def test_expand_topk__worker_raises_batch_scoring_error__propagates():
+    """A worker raising BatchScoringError must surface out of the executor,
+    not silently fail the run."""
+    ds = DataStore(ignore_saved_data=True)
+    for q in ["q1", "q2"]:
+        ds.add_query(q)
+
+    class _Raising(_ConcurrencyTrackingLLM):
+        def generate_score(self, *a, **kw):
+            raise BatchScoringError(
+                query_id="q1", asked_doc_ids=["doc-q1"], attempts=4, reason="missing",
+            )
+
+    llm = _Raising(hold_seconds=0.0)
+    se = _FakeSearchEngine()
+
+    with pytest.raises(BatchScoringError):
+        expand_docset_with_search_engine_top_k(
+            _config(llm_max_workers=4), ds, llm, se, prompt_template="ignored",
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Scoring — cartesian path
+# ─────────────────────────────────────────────────────────────────────
+def test_cartesian__parallel_workers__overlap_and_same_ratings():
+    ds = DataStore(ignore_saved_data=True)
+    for q in ["q1", "q2", "q3", "q4"]:
+        ds.add_query(q)
+    for did in ["d1", "d2"]:
+        ds.add_document(Document(id=did, fields={"title": did}, is_used_to_generate_queries=True))
+
+    llm = _ConcurrencyTrackingLLM(hold_seconds=0.04)
+
+    add_cartesian_product_scores(
+        _config(llm_max_workers=4), ds, llm, prompt_template="ignored",
+    )
+
+    # 4 queries x 2 docs = 8 calls
+    assert llm.total_calls == 8
+    assert llm.max_in_flight > 1
+    # Full cartesian product is rated
+    assert len(ds.get_ratings()) == 8
+
+
+def test_cartesian__single_worker__sequential_call_order_is_deterministic():
+    """At llm_max_workers=1 the call order is deterministic and the cartesian
+    helper iterates queries in budget order. Locks the sequential ordering down
+    so a future refactor can't drift it under llm_max_workers=1."""
+    ds = DataStore(ignore_saved_data=True)
+    for q in ["q1", "q2"]:
+        ds.add_query(q)
+    for did in ["d1", "d2"]:
+        ds.add_document(Document(id=did, fields={"title": did}, is_used_to_generate_queries=True))
+
+    class _OrderRecordingLLM(_ConcurrencyTrackingLLM):
+        def __init__(self):
+            super().__init__(hold_seconds=0.0)
+            self.call_order: List[str] = []
+
+        def generate_score(self, document, query, relevance_scale, explanation=False):
+            self.call_order.append(f"{query}:{document.id}")
+            return super().generate_score(document, query, relevance_scale, explanation)
+
+    llm = _OrderRecordingLLM()
+    add_cartesian_product_scores(
+        _config(llm_max_workers=1), ds, llm, prompt_template="ignored",
+    )
+
+    # q1 then q2; within each, d1 then d2 (insertion order from get_cartesian_prod_docs).
+    assert llm.call_order == ["q1:d1", "q1:d2", "q2:d1", "q2:d2"]
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Combined path — batching AND threading together (the riskiest runtime path)
+# ─────────────────────────────────────────────────────────────────────
+def test_cartesian__batching_and_threading_combined():
+    """``llm_micro_batch_size > 1`` AND ``llm_max_workers > 1`` together.
+
+    Batching and threading are independent features but their combination is the
+    riskiest path. Each worker scores one query's docs through the *batch* path while
+    workers overlap. Confirms they compose: batching (one batch call per query, not one
+    call per (query, doc) pair) + threading (peak in-flight > 1), full cartesian rated.
+    """
+    ds = DataStore(ignore_saved_data=True)
+    for q in ["q1", "q2", "q3", "q4"]:
+        ds.add_query(q)
+    for did in ["d1", "d2"]:
+        ds.add_document(Document(id=did, fields={"title": did}, is_used_to_generate_queries=True))
+
+    llm = _ConcurrencyTrackingLLM(hold_seconds=0.04)
+
+    add_cartesian_product_scores(
+        _config(llm_max_workers=4, llm_micro_batch_size=2), ds, llm, prompt_template="ignored",
+    )
+
+    # Batching: one generate_scores_batch call per query (4), not one per pair (8).
+    assert llm.total_calls == 4
+    # Threading: workers overlapped.
+    assert llm.max_in_flight > 1
+    # Correctness: the full 4 x 2 cartesian product is rated.
+    assert len(ds.get_ratings()) == 8

--- a/tests/llm_search_quality_evaluation/dataset_generator/test_main_query_budget.py
+++ b/tests/llm_search_quality_evaluation/dataset_generator/test_main_query_budget.py
@@ -1,0 +1,120 @@
+from types import SimpleNamespace
+
+from llm_search_quality_evaluation.dataset_generator.main import (
+    add_cartesian_product_scores,
+    expand_docset_with_search_engine_top_k,
+    get_queries_within_budget,
+)
+from llm_search_quality_evaluation.shared.data_store import DataStore
+from llm_search_quality_evaluation.shared.models import Document
+
+
+class FakeLLMService:
+    def __init__(self):
+        self.calls = []
+
+    def generate_score(self, document, query, relevance_scale, explanation=False):
+        self.calls.append((document.id, query, relevance_scale, explanation))
+        return SimpleNamespace(score=1, explanation=None, get_score=lambda: 1)
+
+
+class FakeSearchEngine:
+    def __init__(self):
+        self.queries = []
+
+    def fetch_for_evaluation(self, keyword, query_template, doc_fields):
+        self.queries.append(keyword)
+        return [Document(id=f"doc-{keyword}", fields={"title": [keyword]})]
+
+
+def _config(**overrides):
+    values = {
+        "num_queries_needed": 2,
+        "query_template": "select * from test where userInput(@kw)",
+        "doc_fields": ["title"],
+        "relevance_scale": "graded",
+        "save_llm_explanation": False,
+        "llm_micro_batch_size": 1,
+        "llm_batch_max_retries": 3,
+        "llm_batch_score_prompt": None,
+        "llm_max_workers": 1,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_expand_docset_with_search_engine_top_k__expects__query_budget_respected():
+    data_store = DataStore(ignore_saved_data=True)
+    for query in ["q1", "q2", "q3"]:
+        data_store.add_query(query)
+
+    llm_service = FakeLLMService()
+    search_engine = FakeSearchEngine()
+
+    expand_docset_with_search_engine_top_k(_config(), data_store, llm_service, search_engine,
+                                           prompt_template="ignored at micro_batch_size=1")
+
+    assert search_engine.queries == ["q1", "q2"]
+    assert [call[1] for call in llm_service.calls] == ["q1", "q2"]
+
+
+def test_add_cartesian_product_scores__expects__query_budget_respected():
+    data_store = DataStore(ignore_saved_data=True)
+    for query in ["q1", "q2", "q3"]:
+        data_store.add_query(query)
+    for doc_id in ["d1", "d2"]:
+        data_store.add_document(Document(id=doc_id, fields={"title": [doc_id]}, is_used_to_generate_queries=True))
+
+    llm_service = FakeLLMService()
+
+    add_cartesian_product_scores(_config(), data_store, llm_service,
+                                 prompt_template="ignored at micro_batch_size=1")
+
+    assert [call[1] for call in llm_service.calls] == ["q1", "q1", "q2", "q2"]
+
+
+def test_get_queries_within_budget__prioritizes_user_and_category_over_cached():
+    """Regression: when the cache is full, fresh user/category queries must still make the cut.
+
+    Pre-fix bug: get_queries_within_budget did `queries[:N]` which is purely positional, so
+    cached queries (loaded first into the dict) saturated the budget and category/user queries
+    appended later were silently dropped from scoring.
+    """
+    data_store = DataStore(ignore_saved_data=True)
+    for q in ["cached1", "cached2", "cached3"]:
+        data_store.add_query(q)  # default 'cached'
+    data_store.add_query("user1", source="user")
+    data_store.add_query("category1", source="category")
+
+    selected = get_queries_within_budget(_config(num_queries_needed=2), data_store)
+    selected_texts = [q.text for q in selected]
+    assert selected_texts == ["user1", "category1"]
+
+
+def test_get_queries_within_budget__within_tier_keeps_insertion_order():
+    """Within the same priority tier, the original insertion order is preserved."""
+    data_store = DataStore(ignore_saved_data=True)
+    data_store.add_query("u_first", source="user")
+    data_store.add_query("c_first", source="category")
+    data_store.add_query("u_second", source="user")
+
+    selected = get_queries_within_budget(_config(num_queries_needed=3), data_store)
+    assert [q.text for q in selected] == ["u_first", "c_first", "u_second"]
+
+
+def test_get_queries_within_budget__llm_outranks_cached():
+    data_store = DataStore(ignore_saved_data=True)
+    for q in ["cached1", "cached2"]:
+        data_store.add_query(q)
+    data_store.add_query("llm1", source="llm")
+
+    selected = get_queries_within_budget(_config(num_queries_needed=1), data_store)
+    assert [q.text for q in selected] == ["llm1"]
+
+
+def test_get_queries_within_budget__truncates_to_num_queries_needed():
+    data_store = DataStore(ignore_saved_data=True)
+    for q in ["a", "b", "c"]:
+        data_store.add_query(q)
+    selected = get_queries_within_budget(_config(num_queries_needed=2), data_store)
+    assert [q.text for q in selected] == ["a", "b"]

--- a/tests/llm_search_quality_evaluation/dataset_generator/test_main_save_on_batch_error.py
+++ b/tests/llm_search_quality_evaluation/dataset_generator/test_main_save_on_batch_error.py
@@ -1,0 +1,209 @@
+"""Verify `main()` saves the datastore before re-raising a scoring failure."""
+from __future__ import annotations
+
+import types
+from pathlib import Path
+
+import pytest
+
+from llm_search_quality_evaluation.dataset_generator import main as main_mod
+from llm_search_quality_evaluation.dataset_generator.config import Config
+from llm_search_quality_evaluation.dataset_generator.llm import BatchScoringError
+
+
+class DummyWriter:
+    def write(self, output_destination, data_store):
+        return None
+
+
+def _build_cfg(tmp_path: Path) -> Config:
+    llm_cfg = tmp_path / "llm_cfg.yaml"
+    llm_cfg.write_text("name: mock\nmodel: mock-model\nmax_tokens: 16\n", encoding="utf-8")
+    return Config(
+        query_template=None,
+        search_engine_type="solr",
+        collection_name="testcore",
+        search_engine_url="http://localhost:8983/solr/",
+        documents_filter=None,
+        number_of_docs=1,
+        doc_fields=["title"],
+        queries=None,
+        generate_queries_from_documents=False,
+        num_queries_needed=1,
+        relevance_scale="binary",
+        llm_configuration_file=llm_cfg,
+        output_format="quepid",
+        output_destination=tmp_path,
+        save_llm_explanation=False,
+        llm_explanation_destination=None,
+        id_field=None,
+        rre_query_template=None,
+        rre_query_placeholder=None,
+        verbose=False,
+        datastore_autosave_every_n_updates=None,
+        enable_cartesian_product=False,
+    )
+
+
+def _patch_factories(monkeypatch, cfg, *, save_recorder, raise_during_topk):
+    monkeypatch.setattr(main_mod, "Config", types.SimpleNamespace(load=lambda _p: cfg))
+    monkeypatch.setattr(main_mod, "parse_args",
+                        lambda: types.SimpleNamespace(config="ignored.yaml", verbose=False))
+    monkeypatch.setattr(main_mod, "SearchEngineFactory",
+                        types.SimpleNamespace(build=lambda **kw: object()))
+    monkeypatch.setattr(main_mod, "LLMConfig",
+                        types.SimpleNamespace(load=lambda _p: object()))
+    monkeypatch.setattr(main_mod, "LLMServiceFactory",
+                        types.SimpleNamespace(build_lazy=lambda _cfg: object()))
+    monkeypatch.setattr(main_mod, "WriterFactory",
+                        types.SimpleNamespace(build=lambda _cfg: DummyWriter()))
+
+    class _RecordingDataStore:
+        def __init__(self, *_a, **_kw):
+            self.save_calls = 0
+
+        def save(self):
+            self.save_calls += 1
+            save_recorder.append(self.save_calls)
+
+    monkeypatch.setattr(main_mod, "DataStore", _RecordingDataStore)
+    monkeypatch.setattr(main_mod, "add_cartesian_product_scores",
+                        lambda *_a, **_kw: None)
+
+    def _raise(*_a, **_kw):
+        raise raise_during_topk
+
+    monkeypatch.setattr(main_mod, "expand_docset_with_search_engine_top_k", _raise)
+
+
+def test_main__batch_scoring_error_during_scoring__triggers_save_then_reraises(
+    tmp_path, monkeypatch,
+):
+    cfg = _build_cfg(tmp_path)
+    save_calls: list[int] = []
+    err = BatchScoringError(
+        query_id="q1", asked_doc_ids=["d1"], attempts=4, reason="missing doc_id(s)",
+    )
+    _patch_factories(monkeypatch, cfg, save_recorder=save_calls, raise_during_topk=err)
+
+    with pytest.raises(BatchScoringError):
+        main_mod.main()
+
+    # save() was called before the exception propagated.
+    assert save_calls == [1]
+
+
+def test_main__plain_exception_during_scoring__also_triggers_save_then_reraises(
+    tmp_path, monkeypatch,
+):
+    cfg = _build_cfg(tmp_path)
+    save_calls: list[int] = []
+    err = RuntimeError("search engine timeout")
+    _patch_factories(monkeypatch, cfg, save_recorder=save_calls, raise_during_topk=err)
+
+    with pytest.raises(RuntimeError, match="search engine timeout"):
+        main_mod.main()
+
+    assert save_calls == [1]
+
+
+def test_main__failing_save_does_not_mask_original_scoring_error(
+    tmp_path, monkeypatch,
+):
+    cfg = _build_cfg(tmp_path)
+    _patch_factories(monkeypatch, cfg, save_recorder=[],
+                     raise_during_topk=RuntimeError("scoring blew up"))
+
+    # Replace DataStore with one whose save() always raises.
+    class _BrokenSaveDataStore:
+        def __init__(self, *_a, **_kw):
+            pass
+
+        def save(self):
+            raise OSError("disk full")
+
+    monkeypatch.setattr(main_mod, "DataStore", _BrokenSaveDataStore)
+
+    with pytest.raises(RuntimeError, match="scoring blew up"):
+        main_mod.main()
+
+
+def _patch_factories_with_failing_step(monkeypatch, cfg, *, failing_step_name, err, save_recorder):
+    """Patch main_mod factories and make ``failing_step_name`` raise.
+
+    Covers the contract: any failure during the work phase (query sources,
+    seed fetch, query generation, scoring) triggers save-before-reraise.
+    """
+    monkeypatch.setattr(main_mod, "Config", types.SimpleNamespace(load=lambda _p: cfg))
+    monkeypatch.setattr(main_mod, "parse_args",
+                        lambda: types.SimpleNamespace(config="ignored.yaml", verbose=False))
+    monkeypatch.setattr(main_mod, "SearchEngineFactory",
+                        types.SimpleNamespace(build=lambda **kw: object()))
+    monkeypatch.setattr(main_mod, "LLMConfig",
+                        types.SimpleNamespace(load=lambda _p: object()))
+    monkeypatch.setattr(main_mod, "LLMServiceFactory",
+                        types.SimpleNamespace(build_lazy=lambda _cfg: object()))
+    monkeypatch.setattr(main_mod, "WriterFactory",
+                        types.SimpleNamespace(build=lambda _cfg: DummyWriter()))
+
+    class _RecordingDataStore:
+        def __init__(self, *_a, **_kw):
+            self.save_calls = 0
+
+        def save(self):
+            self.save_calls += 1
+            save_recorder.append(self.save_calls)
+
+    monkeypatch.setattr(main_mod, "DataStore", _RecordingDataStore)
+
+    # No-op stubs for the steps we don't want to exercise. The failing
+    # step is monkeypatched last so it wins.
+    for name in (
+        "add_user_queries",
+        "add_category_queries",
+        "fetch_and_add_seed_documents",
+        "generate_and_add_queries_from_documents",
+        "add_cartesian_product_scores",
+        "expand_docset_with_search_engine_top_k",
+    ):
+        monkeypatch.setattr(main_mod, name, lambda *_a, **_kw: None)
+
+    def _raise(*_a, **_kw):
+        raise err
+
+    monkeypatch.setattr(main_mod, failing_step_name, _raise)
+
+
+@pytest.mark.parametrize("failing_step", [
+    "add_user_queries",
+    "add_category_queries",
+    "fetch_and_add_seed_documents",
+    "generate_and_add_queries_from_documents",
+])
+def test_main__failure_in_any_work_phase_step__triggers_save_then_reraises(
+    tmp_path, monkeypatch, failing_step,
+):
+    """Save-on-failure must cover the entire work phase, not just scoring.
+
+    Regression for the case where ``generate_and_add_queries_from_documents``
+    raised after earlier seed-doc responses had already been applied — those
+    in-memory queries and pre-ratings used to vanish on the exception.
+    """
+    cfg = _build_cfg(tmp_path)
+    # Enable enough of the pipeline that the patched step is actually reached.
+    cfg.generate_queries_from_documents = True
+    cfg.enable_cartesian_product = True
+
+    save_calls: list[int] = []
+    err = RuntimeError(f"{failing_step} blew up")
+    _patch_factories_with_failing_step(
+        monkeypatch, cfg, failing_step_name=failing_step, err=err, save_recorder=save_calls,
+    )
+
+    with pytest.raises(RuntimeError, match=f"{failing_step} blew up"):
+        main_mod.main()
+
+    assert save_calls == [1], (
+        f"save() was not invoked on failure in {failing_step}. The work-phase "
+        f"try/except in main() must cover this step or partial in-memory state is lost."
+    )

--- a/tests/llm_search_quality_evaluation/dataset_generator/test_score_docs_for_query.py
+++ b/tests/llm_search_quality_evaluation/dataset_generator/test_score_docs_for_query.py
@@ -1,0 +1,186 @@
+"""Tests for the `score_docs_for_query` dispatcher in main.py."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Dict, List
+
+import pytest
+
+from llm_search_quality_evaluation.dataset_generator.main import score_docs_for_query
+from llm_search_quality_evaluation.dataset_generator.llm import BatchScoringError
+from llm_search_quality_evaluation.dataset_generator.models import LLMScoreResponse
+from llm_search_quality_evaluation.shared.data_store import DataStore
+from llm_search_quality_evaluation.shared.models import Document
+
+
+def _config(**overrides):
+    values = {
+        "relevance_scale": "binary",
+        "save_llm_explanation": False,
+        "llm_micro_batch_size": 1,
+        "llm_batch_max_retries": 3,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+class FakeLLMService:
+    def __init__(self, score: int = 1):
+        self._score = score
+        self.generate_score_calls: List[tuple] = []
+        self.generate_scores_batch_calls: List[tuple] = []
+
+    def generate_score(self, document: Document, query: str, relevance_scale: str,
+                       explanation: bool = False) -> LLMScoreResponse:
+        self.generate_score_calls.append((document.id, query, relevance_scale, explanation))
+        return LLMScoreResponse(score=self._score, scale=relevance_scale, explanation=None)
+
+    def generate_scores_batch(self, *, query_id, query_text, documents, relevance_scale,
+                              explanation, prompt_template, max_retries) -> Dict[str, LLMScoreResponse]:
+        self.generate_scores_batch_calls.append(
+            (query_id, query_text, [d.id for d in documents], relevance_scale,
+             explanation, max_retries)
+        )
+        return {
+            d.id: LLMScoreResponse(score=self._score, scale=relevance_scale, explanation=None)
+            for d in documents
+        }
+
+
+def _setup_store_with_query_and_docs(num_docs: int):
+    ds = DataStore(ignore_saved_data=True)
+    query = ds.add_query("query text")
+    docs = []
+    for i in range(num_docs):
+        doc = Document(id=f"d{i}", fields={"title": f"t{i}"})
+        ds.add_document(doc)
+        docs.append(doc)
+    return ds, query, docs
+
+
+def test_score_docs_for_query__skips_already_rated_pairs():
+    ds, query, docs = _setup_store_with_query_and_docs(3)
+    ds.create_rating_score(query.id, docs[0].id, 1)
+
+    llm = FakeLLMService(score=1)
+
+    score_docs_for_query(
+        _config(llm_micro_batch_size=2), ds, llm,
+        prompt_template="ignored", query=query, documents=docs,
+    )
+
+    # Only d1 and d2 should be sent.
+    batch_call = llm.generate_scores_batch_calls[0]
+    sent_ids = batch_call[2]
+    assert set(sent_ids) == {"d1", "d2"}
+
+
+def test_score_docs_for_query__splits_25_docs_into_batches_of_10_10_5():
+    ds, query, docs = _setup_store_with_query_and_docs(25)
+    llm = FakeLLMService(score=1)
+
+    score_docs_for_query(
+        _config(llm_micro_batch_size=10), ds, llm,
+        prompt_template="ignored", query=query, documents=docs,
+    )
+
+    batch_sizes = [len(call[2]) for call in llm.generate_scores_batch_calls]
+    assert batch_sizes == [10, 10, 5]
+    # And the legacy single-pair API was never called.
+    assert llm.generate_score_calls == []
+
+
+def test_score_docs_for_query__at_micro_batch_size_1__uses_legacy_single_pair_path():
+    ds, query, docs = _setup_store_with_query_and_docs(3)
+    llm = FakeLLMService(score=1)
+
+    score_docs_for_query(
+        _config(llm_micro_batch_size=1), ds, llm,
+        prompt_template="should-not-be-used", query=query, documents=docs,
+    )
+
+    # Legacy single-pair path: 3 calls, one per doc; batch API never touched.
+    assert [c[0] for c in llm.generate_score_calls] == ["d0", "d1", "d2"]
+    assert llm.generate_scores_batch_calls == []
+
+    # All ratings written.
+    for d in docs:
+        assert ds.has_rating_score(query.id, d.id)
+
+
+def test_score_docs_for_query__on_batch_scoring_error__propagates():
+    ds, query, docs = _setup_store_with_query_and_docs(3)
+
+    class _RaisingLLM(FakeLLMService):
+        def generate_scores_batch(self, **kw):
+            raise BatchScoringError(
+                query_id=query.id, asked_doc_ids=[d.id for d in docs],
+                attempts=4, reason="missing doc_id(s)",
+            )
+
+    llm = _RaisingLLM()
+
+    with pytest.raises(BatchScoringError):
+        score_docs_for_query(
+            _config(llm_micro_batch_size=2), ds, llm,
+            prompt_template="ignored", query=query, documents=docs,
+        )
+
+
+def test_score_docs_for_query__no_pending__early_return():
+    ds, query, docs = _setup_store_with_query_and_docs(2)
+    for d in docs:
+        ds.create_rating_score(query.id, d.id, 1)
+
+    llm = FakeLLMService(score=1)
+    score_docs_for_query(
+        _config(llm_micro_batch_size=2), ds, llm,
+        prompt_template="ignored", query=query, documents=docs,
+    )
+    assert llm.generate_scores_batch_calls == []
+    assert llm.generate_score_calls == []
+
+
+def test_score_docs_for_query__duplicate_doc_ids__deduped_at_micro_batch_size_1():
+    """Pre-batching loop was idempotent against duplicates because has_rating_score
+    was re-checked before each single-pair call; this helper has to dedupe explicitly."""
+    ds = DataStore(ignore_saved_data=True)
+    query = ds.add_query("query text")
+    d1 = Document(id="d1", fields={"title": "t1"})
+    ds.add_document(d1)
+
+    llm = FakeLLMService(score=1)
+    score_docs_for_query(
+        _config(llm_micro_batch_size=1), ds, llm,
+        prompt_template="ignored", query=query, documents=[d1, d1, d1],
+    )
+
+    # Exactly one LLM call, exactly one rating.
+    assert len(llm.generate_score_calls) == 1
+    assert llm.generate_score_calls[0][0] == "d1"
+    assert ds.has_rating_score(query.id, "d1")
+
+
+def test_score_docs_for_query__duplicate_doc_ids__deduped_at_batch_size_greater_than_1():
+    """At size>1 a duplicate would otherwise trip the LLM's one-item-per-input
+    contract: model returns one item for the (only) unique id, service raises
+    'missing doc_id' and retries until abort. Dedup eliminates the failure mode."""
+    ds = DataStore(ignore_saved_data=True)
+    query = ds.add_query("query text")
+    d1 = Document(id="d1", fields={"title": "t1"})
+    d2 = Document(id="d2", fields={"title": "t2"})
+    ds.add_document(d1)
+    ds.add_document(d2)
+
+    llm = FakeLLMService(score=1)
+    score_docs_for_query(
+        _config(llm_micro_batch_size=5), ds, llm,
+        prompt_template="ignored", query=query, documents=[d1, d2, d1, d2, d1],
+    )
+
+    # One batch call carrying exactly the two unique ids, first-occurrence order.
+    assert len(llm.generate_scores_batch_calls) == 1
+    sent_ids = llm.generate_scores_batch_calls[0][2]
+    assert sent_ids == ["d1", "d2"]
+    assert ds.has_rating_score(query.id, "d1")
+    assert ds.has_rating_score(query.id, "d2")

--- a/tests/llm_search_quality_evaluation/dataset_generator/test_seed_fetch_llm_generation.py
+++ b/tests/llm_search_quality_evaluation/dataset_generator/test_seed_fetch_llm_generation.py
@@ -1,0 +1,116 @@
+from llm_search_quality_evaluation.dataset_generator import main as main_mod
+from llm_search_quality_evaluation.shared.data_store import DataStore
+from llm_search_quality_evaluation.shared.models import Document
+
+from category_query_test_utils import (
+    FakeLLMService,
+    FakeSearchEngine,
+    make_config,
+)
+
+
+def test_fetch_and_add_seed_documents__marks_cache_hit_doc_for_cartesian(tmp_path):
+    cfg = make_config(tmp_path)
+    ds = DataStore(path=tmp_path / "ds.json", ignore_saved_data=True)
+    cached = Document(id="d1", fields={"title": "t"}, is_used_to_generate_queries=False)
+    ds.add_document(cached)
+
+    fetched = Document(id="d1", fields={"title": "t"})
+    engine = FakeSearchEngine([fetched])
+
+    main_mod.fetch_and_add_seed_documents(cfg, ds, engine)
+
+    assert "d1" in {d.id for d in ds.get_cartesian_prod_docs()}
+
+
+def test_fetch_and_add_seed_documents__new_docs_flagged(tmp_path):
+    cfg = make_config(tmp_path)
+    ds = DataStore(path=tmp_path / "ds.json", ignore_saved_data=True)
+    engine = FakeSearchEngine([Document(id="d1", fields={"title": "t1"})])
+
+    main_mod.fetch_and_add_seed_documents(cfg, ds, engine)
+
+    assert ds.get_document("d1").is_used_to_generate_queries is True
+
+
+def test_generate_and_add_queries_from_documents__cached_queries_do_not_block_llm_gen(tmp_path):
+    cfg = make_config(tmp_path, num_queries_needed=2, number_of_docs=1)
+    ds = DataStore(path=tmp_path / "ds.json", ignore_saved_data=True)
+    for i in range(5):
+        ds.add_query(f"cached{i}")
+    seed = Document(id="d1", fields={"title": "t1"}, is_used_to_generate_queries=True)
+    ds.add_document(seed)
+
+    llm = FakeLLMService(queries_per_doc={"d1": ["fresh-llm-query"]})
+
+    main_mod.generate_and_add_queries_from_documents(cfg, ds, llm, [seed])
+
+    assert llm.generate_queries_calls == ["d1"]
+    fresh = next((q for q in ds.get_queries() if q.text == "fresh-llm-query"), None)
+    assert fresh is not None
+    assert fresh.source == "llm"
+
+
+def test_generate_and_add_queries_from_documents__existing_llm_queries_count_against_budget(tmp_path):
+    cfg = make_config(tmp_path, num_queries_needed=2, number_of_docs=1)
+    ds = DataStore(path=tmp_path / "ds.json", ignore_saved_data=True)
+    ds.add_query("pre-llm-1", source="llm")
+    ds.add_query("pre-llm-2", source="llm")
+    seed = Document(id="d1", fields={"title": "t1"}, is_used_to_generate_queries=True)
+    ds.add_document(seed)
+
+    llm = FakeLLMService(queries_per_doc={"d1": ["should-not-be-generated"]})
+
+    main_mod.generate_and_add_queries_from_documents(cfg, ds, llm, [seed])
+
+    assert llm.generate_queries_calls == []
+    assert not any(q.text == "should-not-be-generated" for q in ds.get_queries())
+
+
+def test_generate_and_add_queries_from_documents__no_extra_llm_call_after_inner_loop_fills_budget(tmp_path):
+    cfg = make_config(tmp_path, num_queries_needed=1, number_of_docs=1)
+    ds = DataStore(path=tmp_path / "ds.json", ignore_saved_data=True)
+    seed1 = Document(id="d1", fields={"title": "t1"}, is_used_to_generate_queries=True)
+    seed2 = Document(id="d2", fields={"title": "t2"}, is_used_to_generate_queries=True)
+    ds.add_document(seed1)
+    ds.add_document(seed2)
+
+    llm = FakeLLMService(queries_per_doc={"d1": ["q1"], "d2": ["q2"]})
+
+    main_mod.generate_and_add_queries_from_documents(cfg, ds, llm, [seed1, seed2])
+
+    assert llm.generate_queries_calls == ["d1"]
+
+
+def test_generate_and_add_queries_from_documents__user_and_category_fill_budget_skip_llm(tmp_path):
+    cfg = make_config(tmp_path, num_queries_needed=2, number_of_docs=1)
+    ds = DataStore(path=tmp_path / "ds.json", ignore_saved_data=True)
+    ds.add_query("u1", source="user")
+    ds.add_query("c1", source="category")
+    seed = Document(id="d1", fields={"title": "t1"}, is_used_to_generate_queries=True)
+    ds.add_document(seed)
+
+    llm = FakeLLMService(queries_per_doc={"d1": ["never-added"]})
+
+    main_mod.generate_and_add_queries_from_documents(cfg, ds, llm, [seed])
+
+    assert llm.generate_queries_calls == []
+    assert not any(q.text == "never-added" for q in ds.get_queries())
+
+
+def test_generate_and_add_queries_from_documents__pre_rates_seed_doc_with_max(tmp_path):
+    cfg = make_config(tmp_path, num_queries_needed=2, number_of_docs=1)
+    ds = DataStore(path=tmp_path / "ds.json", ignore_saved_data=True)
+    seed = Document(id="d1", fields={"title": "t1"}, is_used_to_generate_queries=True)
+    ds.add_document(seed)
+
+    llm = FakeLLMService(queries_per_doc={"d1": ["the synthetic query"]})
+
+    main_mod.generate_and_add_queries_from_documents(cfg, ds, llm, [seed])
+
+    queries = ds.get_queries()
+    assert any(q.text == "the synthetic query" for q in queries)
+    generated = next(q for q in queries if q.text == "the synthetic query")
+    rating = ds.rating_by_pair.get((generated.id, "d1"))
+    assert rating is not None
+    assert rating.score == max(cfg.relevance_label_set)

--- a/tests/llm_search_quality_evaluation/shared/search_engines/test_fetch_field_values.py
+++ b/tests/llm_search_quality_evaluation/shared/search_engines/test_fetch_field_values.py
@@ -1,0 +1,416 @@
+"""Per-engine `fetch_field_values` tests (engine-driven value discovery).
+
+Each engine's `fetch_field_values` is a separate code path from `_search` (different
+return type, different transport, raw response navigation), so these tests stub
+`requests.get` (Solr) or `requests.post` (ES/OS/Vespa) directly.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import requests
+from requests.exceptions import HTTPError
+
+from llm_search_quality_evaluation.shared.search_engines import (
+    ElasticsearchSearchEngine,
+    OpenSearchEngine,
+    SolrSearchEngine,
+    VespaSearchEngine,
+)
+
+
+# ─────────────── shared HTTP-stub helpers ───────────────
+
+class _Resp:
+    def __init__(self, body, status_code=200):
+        self._body = body
+        self.status_code = status_code
+
+    def json(self):
+        return self._body
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise HTTPError(f"status {self.status_code}")
+
+    @property
+    def request(self):
+        # Used by Solr code path's debug log; not asserted on.
+        return type("_Req", (), {"url": "stubbed"})()
+
+
+def _capture_get(monkeypatch, body, status_code=200):
+    calls = {}
+
+    def _get(url, headers=None, params=None, **kwargs):
+        calls["url"] = url
+        calls["headers"] = headers
+        calls["params"] = params
+        calls["kwargs"] = kwargs
+        return _Resp(body, status_code)
+
+    monkeypatch.setattr(requests, "get", _get)
+    return calls
+
+
+def _capture_post(monkeypatch, body, status_code=200):
+    calls = {}
+
+    def _post(url, headers=None, json=None, **kwargs):
+        calls["url"] = url
+        calls["headers"] = headers
+        calls["json"] = json
+        calls["kwargs"] = kwargs
+        return _Resp(body, status_code)
+
+    monkeypatch.setattr(requests, "post", _post)
+    return calls
+
+
+# Solr engine `__init__` issues a GET to fetch the unique key. Avoid hitting the network.
+@pytest.fixture
+def solr_engine(monkeypatch):
+    monkeypatch.setattr(
+        requests, "get",
+        lambda *a, **kw: _Resp({"uniqueKey": "id"}),
+    )
+    return SolrSearchEngine("http://fake-solr/collection/")
+
+
+# ───────────────── Solr ─────────────────
+
+
+def _write_solr_facet_template(tmp_path: Path) -> Path:
+    p = tmp_path / "facet_solr.json"
+    p.write_text(
+        json.dumps({"q": "*:*", "facet": "true", "facet.field": "genres", "facet.limit": 5, "rows": 0}),
+        encoding="utf-8",
+    )
+    return p
+
+
+def test_solr_fetch_field_values__alternating_array_drops_counts_preserves_order(solr_engine, monkeypatch, tmp_path):
+    body = {"facet_counts": {"facet_fields": {"genres": ["comedy", 12, "action", 4, "drama", 1]}}}
+    calls = _capture_get(monkeypatch, body)
+    template = _write_solr_facet_template(tmp_path)
+
+    values = solr_engine.fetch_field_values(template, "genres")
+
+    assert values == ["comedy", "action", "drama"]
+    assert calls["url"].endswith("/select")
+    assert calls["params"]["wt"] == "json"
+    assert calls["params"]["facet.field"] == "genres"
+
+
+def test_solr_fetch_field_values__numeric_values_coerce_and_whitespace_dropped(solr_engine, monkeypatch, tmp_path):
+    body = {"facet_counts": {"facet_fields": {"year": [2020, 9, 2021, 4, "  ", 1, "   2022 ", 1]}}}
+    _capture_get(monkeypatch, body)
+    template = _write_solr_facet_template(tmp_path)
+
+    values = solr_engine.fetch_field_values(template, "year")
+
+    assert values == ["2020", "2021", "2022"]
+
+
+def test_solr_fetch_field_values__missing_facet_counts_raises(solr_engine, monkeypatch, tmp_path):
+    _capture_get(monkeypatch, {"response": {"docs": []}})
+    template = _write_solr_facet_template(tmp_path)
+    with pytest.raises(ValueError, match="facet_counts"):
+        solr_engine.fetch_field_values(template, "genres")
+
+
+def test_solr_fetch_field_values__wrong_field_key_raises(solr_engine, monkeypatch, tmp_path):
+    _capture_get(monkeypatch, {"facet_counts": {"facet_fields": {"category": ["x", 1]}}})
+    template = _write_solr_facet_template(tmp_path)
+    with pytest.raises(ValueError, match="genres"):
+        solr_engine.fetch_field_values(template, "genres")
+
+
+def test_solr_fetch_field_values__field_not_a_list_raises(solr_engine, monkeypatch, tmp_path):
+    _capture_get(monkeypatch, {"facet_counts": {"facet_fields": {"genres": "comedy,action"}}})
+    template = _write_solr_facet_template(tmp_path)
+    with pytest.raises(ValueError, match="must be a list"):
+        solr_engine.fetch_field_values(template, "genres")
+
+
+def test_solr_fetch_field_values__odd_length_array_raises(solr_engine, monkeypatch, tmp_path):
+    _capture_get(monkeypatch, {"facet_counts": {"facet_fields": {"genres": ["comedy", 1, "action"]}}})
+    template = _write_solr_facet_template(tmp_path)
+    with pytest.raises(ValueError, match="even length"):
+        solr_engine.fetch_field_values(template, "genres")
+
+
+def test_solr_fetch_field_values__empty_array_returns_empty_list_silently(solr_engine, monkeypatch, tmp_path, caplog):
+    _capture_get(monkeypatch, {"facet_counts": {"facet_fields": {"genres": []}}})
+    template = _write_solr_facet_template(tmp_path)
+    with caplog.at_level("WARNING"):
+        values = solr_engine.fetch_field_values(template, "genres")
+    assert values == []
+    # No engine-side warning — the single warning lives in add_category_queries.
+    assert not [r for r in caplog.records if "no values" in r.getMessage()]
+
+
+def test_solr_fetch_field_values__http_error_propagates(solr_engine, monkeypatch, tmp_path):
+    _capture_get(monkeypatch, {}, status_code=500)
+    template = _write_solr_facet_template(tmp_path)
+    with pytest.raises(HTTPError):
+        solr_engine.fetch_field_values(template, "genres")
+
+
+def test_solr_fetch_field_values__does_not_route_through_search(solr_engine, monkeypatch, tmp_path):
+    """fetch_field_values must not call self._search() (which parses hits and discards
+    facet_counts). Greppable contract from the plan."""
+    body = {"facet_counts": {"facet_fields": {"genres": ["comedy", 1]}}}
+    _capture_get(monkeypatch, body)
+
+    sentinel = {"called": False}
+
+    def _spy_search(*a, **kw):
+        sentinel["called"] = True
+        raise AssertionError("_search should not be called")
+
+    monkeypatch.setattr(solr_engine, "_search", _spy_search)
+    template = _write_solr_facet_template(tmp_path)
+    solr_engine.fetch_field_values(template, "genres")
+    assert sentinel["called"] is False
+
+
+# ───────────────── Elasticsearch ─────────────────
+
+
+def _write_es_agg_template(tmp_path: Path) -> Path:
+    p = tmp_path / "facet_es.json"
+    p.write_text(
+        json.dumps({
+            "size": 0,
+            "aggs": {"genres": {"terms": {"field": "genres.keyword", "size": 5}}}
+        }),
+        encoding="utf-8",
+    )
+    return p
+
+
+def test_es_fetch_field_values__buckets_returned_in_order(monkeypatch, tmp_path):
+    body = {
+        "aggregations": {
+            "genres": {"buckets": [
+                {"key": "comedy", "doc_count": 12},
+                {"key": "action", "doc_count": 4},
+            ]}
+        }
+    }
+    calls = _capture_post(monkeypatch, body)
+    engine = ElasticsearchSearchEngine("http://fake-es/index/")
+    template = _write_es_agg_template(tmp_path)
+
+    values = engine.fetch_field_values(template, "genres")
+
+    assert values == ["comedy", "action"]
+    assert calls["url"].endswith("/_search")
+    # The internal terms.field stays `genres.keyword` (convention navigates by result key).
+    assert calls["json"]["aggs"]["genres"]["terms"]["field"] == "genres.keyword"
+
+
+def test_es_fetch_field_values__numeric_and_boolean_keys_coerce(monkeypatch, tmp_path):
+    body = {"aggregations": {"is_premium": {"buckets": [
+        {"key": True, "doc_count": 9},
+        {"key": False, "doc_count": 1},
+    ]}}}
+    _capture_post(monkeypatch, body)
+    engine = ElasticsearchSearchEngine("http://fake-es/index/")
+    template = _write_es_agg_template(tmp_path)
+
+    assert engine.fetch_field_values(template, "is_premium") == ["True", "False"]
+
+
+def test_es_fetch_field_values__mismatched_agg_key_raises_with_convention_message(monkeypatch, tmp_path):
+    body = {"aggregations": {"category": {"buckets": [{"key": "comedy"}]}}}  # named 'category', not 'genres'
+    _capture_post(monkeypatch, body)
+    engine = ElasticsearchSearchEngine("http://fake-es/index/")
+    template = _write_es_agg_template(tmp_path)
+
+    with pytest.raises(ValueError, match="aggregation result key must equal"):
+        engine.fetch_field_values(template, "genres")
+
+
+def test_es_fetch_field_values__keyed_buckets_form_raises(monkeypatch, tmp_path):
+    """`"keyed": true` returns buckets as a dict; unsupported."""
+    body = {"aggregations": {"genres": {"buckets": {"comedy": {"doc_count": 12}}}}}
+    _capture_post(monkeypatch, body)
+    engine = ElasticsearchSearchEngine("http://fake-es/index/")
+    template = _write_es_agg_template(tmp_path)
+
+    with pytest.raises(ValueError, match="Keyed-bucket"):
+        engine.fetch_field_values(template, "genres")
+
+
+def test_es_fetch_field_values__empty_buckets_returns_empty_list_silently(monkeypatch, tmp_path):
+    body = {"aggregations": {"genres": {"buckets": []}}}
+    _capture_post(monkeypatch, body)
+    engine = ElasticsearchSearchEngine("http://fake-es/index/")
+    template = _write_es_agg_template(tmp_path)
+    assert engine.fetch_field_values(template, "genres") == []
+
+
+def test_es_fetch_field_values__http_error_propagates(monkeypatch, tmp_path):
+    _capture_post(monkeypatch, {}, status_code=500)
+    engine = ElasticsearchSearchEngine("http://fake-es/index/")
+    template = _write_es_agg_template(tmp_path)
+    with pytest.raises(HTTPError):
+        engine.fetch_field_values(template, "genres")
+
+
+def test_es_agg_keyword_subfield_does_not_require_keyword_in_doc_fields(monkeypatch, tmp_path):
+    """Convention test: aggregating on `genres.keyword` while naming the agg `genres` is supported.
+    The result-key convention navigates by the agg's name, not its internal terms.field.
+    `doc_fields=[genres]` (no `.keyword`) is fine — no engine-level coupling exists between
+    the aggregation's internal field and Config.doc_fields.
+    """
+    body = {"aggregations": {"genres": {"buckets": [{"key": "comedy"}]}}}
+    _capture_post(monkeypatch, body)
+    engine = ElasticsearchSearchEngine("http://fake-es/index/")
+    template = _write_es_agg_template(tmp_path)
+    assert engine.fetch_field_values(template, "genres") == ["comedy"]
+
+
+# ───────────────── OpenSearch ─────────────────
+
+
+def test_opensearch_fetch_field_values__mirrors_es_behaviour(monkeypatch, tmp_path):
+    body = {"aggregations": {"genres": {"buckets": [{"key": "drama"}, {"key": "horror"}]}}}
+    _capture_post(monkeypatch, body)
+    engine = OpenSearchEngine("http://fake-os/index/")
+    template = _write_es_agg_template(tmp_path)
+    assert engine.fetch_field_values(template, "genres") == ["drama", "horror"]
+
+
+def test_opensearch_fetch_field_values__keyed_buckets_form_raises(monkeypatch, tmp_path):
+    body = {"aggregations": {"genres": {"buckets": {"drama": {"doc_count": 1}}}}}
+    _capture_post(monkeypatch, body)
+    engine = OpenSearchEngine("http://fake-os/index/")
+    template = _write_es_agg_template(tmp_path)
+    with pytest.raises(ValueError, match="Keyed-bucket"):
+        engine.fetch_field_values(template, "genres")
+
+
+# ───────────────── Vespa ─────────────────
+
+
+def _write_vespa_yql(tmp_path: Path) -> Path:
+    p = tmp_path / "facet_vespa.yql"
+    p.write_text(
+        "select * from sources * where true | all(group(genres) max(5) each(output(count())))\n",
+        encoding="utf-8",
+    )
+    return p
+
+
+def _vespa_grouping_response(field: str, values_with_counts):
+    """Build a canonical Vespa grouping response shape."""
+    bucket_children = [
+        {
+            "id": f"group:string:{v}",
+            "value": v,
+            "fields": {"count()": c},
+        }
+        for v, c in values_with_counts
+    ]
+    return {
+        "root": {
+            "id": "toplevel",
+            "children": [
+                {
+                    "id": "group:root:0",
+                    "children": [
+                        {
+                            "id": f"grouplist:{field}",
+                            "label": field,
+                            "children": bucket_children,
+                        }
+                    ],
+                }
+            ],
+        }
+    }
+
+
+def test_vespa_fetch_field_values__canonical_response_returns_values(monkeypatch, tmp_path):
+    body = _vespa_grouping_response("genres", [("comedy", 12), ("action", 4)])
+    calls = _capture_post(monkeypatch, body)
+    engine = VespaSearchEngine("http://fake-vespa/movie/")
+    template = _write_vespa_yql(tmp_path)
+
+    values = engine.fetch_field_values(template, "genres")
+
+    assert values == ["comedy", "action"]
+    assert calls["url"].endswith("/search/")
+    assert calls["json"]["hits"] == 0
+    assert calls["json"]["presentation.format"] == "json"
+    assert "group(genres)" in calls["json"]["yql"]
+
+
+def test_vespa_fetch_field_values__missing_grouplist_raises_with_seen_nodes(monkeypatch, tmp_path):
+    body = {"root": {"id": "toplevel", "children": [
+        {"id": "group:root:0", "children": [{"id": "grouplist:other"}]}
+    ]}}
+    _capture_post(monkeypatch, body)
+    engine = VespaSearchEngine("http://fake-vespa/movie/")
+    template = _write_vespa_yql(tmp_path)
+
+    with pytest.raises(ValueError) as exc:
+        engine.fetch_field_values(template, "genres")
+    msg = str(exc.value)
+    assert "no grouplist found for field 'genres'" in msg
+    assert "attribute" in msg  # precondition reminder
+    assert "grouplist:other" in msg  # encountered nodes captured
+
+
+def test_vespa_fetch_field_values__deeply_nested_grouplist_resolved_by_recursive_walk(monkeypatch, tmp_path):
+    """The recursive walk must find a grouplist that sits one level deeper than the canonical
+    layout — real Vespa responses sometimes nest the grouplist below the `group:root:0` node."""
+    body = {
+        "root": {
+            "id": "toplevel",
+            "children": [
+                {
+                    "id": "group:root:0",
+                    "children": [
+                        {
+                            "id": "wrapper",
+                            "children": [
+                                {
+                                    "id": "grouplist:genres",
+                                    "label": "genres",
+                                    "children": [
+                                        {"id": "group:string:noir", "value": "noir"},
+                                    ],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ],
+        }
+    }
+    _capture_post(monkeypatch, body)
+    engine = VespaSearchEngine("http://fake-vespa/movie/")
+    template = _write_vespa_yql(tmp_path)
+    assert engine.fetch_field_values(template, "genres") == ["noir"]
+
+
+def test_vespa_fetch_field_values__empty_grouplist_returns_empty_list_silently(monkeypatch, tmp_path):
+    body = _vespa_grouping_response("genres", [])
+    _capture_post(monkeypatch, body)
+    engine = VespaSearchEngine("http://fake-vespa/movie/")
+    template = _write_vespa_yql(tmp_path)
+    assert engine.fetch_field_values(template, "genres") == []
+
+
+def test_vespa_fetch_field_values__http_error_propagates(monkeypatch, tmp_path):
+    _capture_post(monkeypatch, {}, status_code=500)
+    engine = VespaSearchEngine("http://fake-vespa/movie/")
+    template = _write_vespa_yql(tmp_path)
+    with pytest.raises(HTTPError):
+        engine.fetch_field_values(template, "genres")

--- a/tests/llm_search_quality_evaluation/shared/search_engines/test_search_engine_factory.py
+++ b/tests/llm_search_quality_evaluation/shared/search_engines/test_search_engine_factory.py
@@ -1,0 +1,21 @@
+import pytest
+from pydantic import HttpUrl
+
+from llm_search_quality_evaluation.shared.search_engines import SearchEngineFactory, VespaSearchEngine
+
+
+def test_build_vespa__expects__vespa_search_engine():
+    search_engine = SearchEngineFactory.build(
+        search_engine_type="vespa",
+        endpoint=HttpUrl("http://localhost:8080/doc/"),
+    )
+
+    assert isinstance(search_engine, VespaSearchEngine)
+
+
+def test_build_unsupported_search_engine__expects__value_error():
+    with pytest.raises(ValueError, match="Unsupported search engine: unsupported"):
+        SearchEngineFactory.build(
+            search_engine_type="unsupported",
+            endpoint=HttpUrl("http://localhost:8080/doc/"),
+        )

--- a/tests/llm_search_quality_evaluation/shared/search_engines/test_vespa_search_engine.py
+++ b/tests/llm_search_quality_evaluation/shared/search_engines/test_vespa_search_engine.py
@@ -126,9 +126,13 @@ def test_fetch_for_query_generation__expects__builds_valid_yql_handles_hits_and_
     payload = calls["json"]
     assert payload["hits"] == number_of_docs
 
-    # YQL sanity
+    # YQL sanity: documentid is always projected (so `_search` can return the user doc id
+    # rather than the internal GID), alongside the requested fields.
     yql = payload["yql"]
-    assert re.search(r"select (title,\s*description|description,\s*title) from doc where ", yql)
+    assert re.search(r"^select [^f]+ from doc where ", yql)
+    assert "documentid" in yql
+    assert "title" in yql
+    assert "description" in yql
     assert 'title contains "Helicopter"' in yql
     assert ('(description contains "BOGOTA" OR description contains "Colombia")' in yql or
             '(description contains "Colombia" OR description contains "BOGOTA")' in yql)

--- a/tests/llm_search_quality_evaluation/shared/test_data_store_concurrency.py
+++ b/tests/llm_search_quality_evaluation/shared/test_data_store_concurrency.py
@@ -1,0 +1,245 @@
+"""Concurrency tests for :class:`DataStore`.
+
+Cover the RLock contract directly: mutators under N threads must not lose
+updates, and the autosave-during-mutations path must never write a snapshot
+containing dangling rating references (a rating whose query or doc isn't in
+the saved set).
+"""
+from __future__ import annotations
+
+import json
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Optional
+from unittest.mock import patch
+
+from llm_search_quality_evaluation.shared.data_store import DataStore
+from llm_search_quality_evaluation.shared.models import Document
+
+
+def test_data_store__concurrent_add_document_and_rating__no_lost_updates(tmp_path: Path):
+    ds = DataStore(path=tmp_path / "ds.json", ignore_saved_data=True)
+    query = ds.add_query("q1")
+
+    n_workers = 200
+
+    def _worker(i: int) -> None:
+        doc = Document(id=f"d{i}", fields={"title": f"t{i}"})
+        ds.add_document(doc)
+        ds.create_rating_score(query.id, doc.id, 1)
+
+    with ThreadPoolExecutor(max_workers=16) as ex:
+        list(ex.map(_worker, range(n_workers)))
+
+    assert len(ds.get_documents()) == n_workers
+    assert len(ds.get_ratings()) == n_workers
+    # Every rating points to a real doc and the one real query.
+    docs_ids = {d.id for d in ds.get_documents()}
+    for r in ds.get_ratings():
+        assert r.query_id == query.id
+        assert r.doc_id in docs_ids
+
+
+def test_data_store__concurrent_create_rating_score_same_pair__idempotent(tmp_path: Path):
+    """The has_rating_score → create_rating_score idiom is not atomic across
+    threads, but create_rating_score is idempotent on the (query, doc) key —
+    the second writer is a no-op. Verifies the duplicate-write race is harmless.
+    """
+    ds = DataStore(path=tmp_path / "ds.json", ignore_saved_data=True)
+    query = ds.add_query("q1")
+    doc = Document(id="d1", fields={"title": "t"})
+    ds.add_document(doc)
+
+    def _worker(_: int):
+        ds.create_rating_score(query.id, doc.id, 1)
+
+    with ThreadPoolExecutor(max_workers=8) as ex:
+        list(ex.map(_worker, range(64)))
+
+    assert len(ds.get_ratings()) == 1
+
+
+def test_data_store__autosave_under_concurrent_mutations__snapshot_has_no_dangling_refs(
+    tmp_path: Path,
+):
+    """Most-load-bearing concurrency test: pound `create_rating_score` from many
+    threads with `autosave_every_n_updates=1`. Every autosave must produce a valid
+    snapshot (parses as JSON; every rating references a query/doc that also
+    appears in the saved set). Without `save()` holding the lock during
+    `model_dump`, autosave could capture a rating whose query/doc was being
+    inserted concurrently.
+    """
+    path = tmp_path / "ds.json"
+    ds = DataStore(path=path, ignore_saved_data=True, autosave_every_n_updates=1)
+
+    n_workers = 100
+
+    def _worker(i: int) -> None:
+        # Each worker adds a brand-new query AND brand-new doc, then a rating
+        # tying them together. Three updates per worker, autosave fires on each.
+        q = ds.add_query(f"query-{i}")
+        doc = Document(id=f"d-{i}", fields={"title": f"t{i}"})
+        ds.add_document(doc)
+        ds.create_rating_score(q.id, doc.id, 1)
+
+    with ThreadPoolExecutor(max_workers=16) as ex:
+        list(ex.map(_worker, range(n_workers)))
+
+    # In-memory invariants
+    assert len(ds.get_queries()) == n_workers
+    assert len(ds.get_documents()) == n_workers
+    assert len(ds.get_ratings()) == n_workers
+
+    # Final on-disk snapshot must parse and have no dangling refs
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    saved_query_ids = {q["id"] for q in raw["queries"]}
+    saved_doc_ids = {d["id"] for d in raw["docs"]}
+    for r in raw["ratings"]:
+        assert r["query_id"] in saved_query_ids, f"dangling query_id={r['query_id']}"
+        assert r["doc_id"] in saved_doc_ids, f"dangling doc_id={r['doc_id']}"
+
+
+def test_data_store__load_called_inside_init__lock_already_initialized(tmp_path: Path):
+    """Regression guard: DataStore.__init__ must assign self._lock *before* load().
+
+    load() calls add_document / add_query / _add_rating which all acquire the
+    lock; if _lock isn't set yet, the first call would `AttributeError`.
+    """
+    path = tmp_path / "ds.json"
+    # Prep a non-empty saved store so load() actually does work
+    ds0 = DataStore(path=path, ignore_saved_data=True)
+    q = ds0.add_query("q1")
+    doc = Document(id="d1", fields={"title": "t"})
+    ds0.add_document(doc)
+    ds0.create_rating_score(q.id, doc.id, 1)
+    ds0.save()
+
+    # Without the init-before-load fix this raises AttributeError on first add_document
+    ds1 = DataStore(path=path)
+    assert len(ds1.get_queries()) == 1
+    assert len(ds1.get_documents()) == 1
+    assert len(ds1.get_ratings()) == 1
+
+
+def test_data_store__autosave_does_not_truncate_cache_during_load(tmp_path: Path):
+    """Regression guard for the load-with-autosave corruption.
+
+    Repro from the original report: 3 docs / 3 queries / 3 ratings on disk,
+    open with ``autosave_every_n_updates=4``. Without suppressing autosave
+    during replay, the counter crosses 4 mid-load and writes a partial
+    snapshot back over the source file — final on-disk state observed as
+    (3 docs, 3 queries, 2 ratings).
+    """
+    path = tmp_path / "ds.json"
+
+    # Prepare the canonical 3/3/3 store.
+    ds0 = DataStore(path=path, ignore_saved_data=True)
+    docs = [Document(id=f"d{i}", fields={"title": f"t{i}"}) for i in range(3)]
+    queries = [ds0.add_query(f"q{i}") for i in range(3)]
+    for d in docs:
+        ds0.add_document(d)
+    for q, d in zip(queries, docs):
+        ds0.create_rating_score(q.id, d.id, 1)
+    ds0.save()
+
+    # Sanity: the file is what we expect before the next open.
+    pre = json.loads(path.read_text(encoding="utf-8"))
+    assert len(pre["docs"]) == 3
+    assert len(pre["queries"]) == 3
+    assert len(pre["ratings"]) == 3
+
+    # Open with autosave_every_n_updates=4 — would previously corrupt the file
+    # during load() because the mid-load counter crosses 4.
+    ds1 = DataStore(path=path, autosave_every_n_updates=4)
+
+    # In-memory state is fully loaded.
+    assert len(ds1.get_documents()) == 3
+    assert len(ds1.get_queries()) == 3
+    assert len(ds1.get_ratings()) == 3
+
+    # On-disk state is unchanged — no partial snapshot was written.
+    post = json.loads(path.read_text(encoding="utf-8"))
+    assert post == pre
+
+
+def test_data_store__autosave_counter_resets_after_load(tmp_path: Path):
+    """After load(), the next real mutation should account from a fresh
+    autosave counter — not from whatever residual the replay left behind.
+    Otherwise opening a near-threshold store would autosave on the first
+    user mutation, masking the suppression fix above.
+    """
+    path = tmp_path / "ds.json"
+
+    # Prepare a stored 3/3/3 store as before.
+    ds0 = DataStore(path=path, ignore_saved_data=True)
+    docs = [Document(id=f"d{i}", fields={"title": f"t{i}"}) for i in range(3)]
+    queries = [ds0.add_query(f"q{i}") for i in range(3)]
+    for d in docs:
+        ds0.add_document(d)
+    for q, d in zip(queries, docs):
+        ds0.create_rating_score(q.id, d.id, 1)
+    ds0.save()
+    pre = json.loads(path.read_text(encoding="utf-8"))
+
+    # Open with autosave threshold larger than the number of mutations
+    # we'll do next — autosave should NOT fire after one extra add.
+    ds1 = DataStore(path=path, autosave_every_n_updates=10)
+    new_doc = Document(id="d-extra", fields={"title": "t-extra"})
+    ds1.add_document(new_doc)
+
+    # File on disk still reflects only the pre-existing state — the in-memory
+    # change has not been autosaved yet.
+    after_one_mutation = json.loads(path.read_text(encoding="utf-8"))
+    assert after_one_mutation == pre
+
+
+def test_data_store__autosave_io_runs_outside_lock(tmp_path: Path):
+    """Regression guard for autosave holding the lock through file I/O.
+
+    Strategy: intercept the lowest-level file write that any autosave
+    implementation must go through (``Path.write_text``) and, at that moment,
+    probe whether the DataStore's lock is held by *anyone*. If the mutator
+    that triggered the autosave is still holding it, the autosave is
+    serializing worker writes behind disk I/O.
+
+    The probe is ``ds._lock.acquire(blocking=False)`` from a separate thread:
+    RLock is owner-aware, so the probe fails iff some *other* thread holds
+    the lock at that instant.
+    """
+    path = tmp_path / "ds.json"
+    ds = DataStore(path=path, ignore_saved_data=True, autosave_every_n_updates=1)
+
+    real_write_text = Path.write_text
+    probe_results: list[bool] = []
+
+    def write_text_probe(self_path, *args, **kwargs):
+        # Probe from a different thread so we can detect when the mutator
+        # thread is the lock owner — `_lock.acquire(blocking=False)` from
+        # the same thread always succeeds on an RLock (re-entry).
+        result: list[Optional[bool]] = [None]
+
+        def probe():
+            acquired = ds._lock.acquire(blocking=False)
+            if acquired:
+                ds._lock.release()
+            result[0] = acquired
+
+        t = threading.Thread(target=probe)
+        t.start()
+        t.join(timeout=1.0)
+        probe_results.append(bool(result[0]))
+        return real_write_text(self_path, *args, **kwargs)
+
+    with patch.object(Path, "write_text", write_text_probe):
+        # Single mutation triggers autosave (threshold=1).
+        ds.add_document(Document(id="d1", fields={"title": "t"}))
+
+    assert probe_results, "autosave write_text was never invoked"
+    # The bug case: probe returns False because the outer mutator still
+    # holds ds._lock during file I/O. The fix case: probe returns True
+    # because the lock was released before write_text was called.
+    assert all(probe_results), (
+        f"Autosave is holding ds._lock through file I/O — lock-acquired "
+        f"probe results: {probe_results}"
+    )

--- a/tests/llm_search_quality_evaluation/shared/test_data_store_mark_query_seed.py
+++ b/tests/llm_search_quality_evaluation/shared/test_data_store_mark_query_seed.py
@@ -1,0 +1,45 @@
+import logging
+from pathlib import Path
+
+import pytest
+
+from llm_search_quality_evaluation.shared.data_store import DataStore
+from llm_search_quality_evaluation.shared.models import Document
+
+
+@pytest.fixture
+def tmp_db_path(tmp_path: Path) -> Path:
+    return tmp_path / "datastore.json"
+
+
+@pytest.fixture
+def ds(tmp_db_path: Path) -> DataStore:
+    return DataStore(path=tmp_db_path, ignore_saved_data=True)
+
+
+def test_mark_document_as_query_seed__flips_flag_when_false(ds):
+    doc = Document(id="d1", fields={"title": "t"}, is_used_to_generate_queries=False)
+    ds.add_document(doc)
+    assert ds.get_document("d1").is_used_to_generate_queries is False
+
+    ds.mark_document_as_query_seed("d1")
+    assert ds.get_document("d1").is_used_to_generate_queries is True
+    assert "d1" in {d.id for d in ds.get_cartesian_prod_docs()}
+
+
+def test_mark_document_as_query_seed__idempotent(ds):
+    doc = Document(id="d1", fields={"title": "t"}, is_used_to_generate_queries=False)
+    ds.add_document(doc)
+
+    ds.mark_document_as_query_seed("d1")
+    ds.mark_document_as_query_seed("d1")
+
+    assert ds.get_document("d1").is_used_to_generate_queries is True
+    assert len(ds.get_documents()) == 1
+
+
+def test_mark_document_as_query_seed__unknown_id_is_safe_noop(ds, caplog):
+    caplog.set_level(logging.WARNING)
+    ds.mark_document_as_query_seed("missing")
+    assert len(ds.get_documents()) == 0
+    assert any("doc_not_found" in rec.getMessage() for rec in caplog.records)

--- a/tests/llm_search_quality_evaluation/shared/test_normalize_discovered_field_values.py
+++ b/tests/llm_search_quality_evaluation/shared/test_normalize_discovered_field_values.py
@@ -1,0 +1,34 @@
+import pytest
+
+from llm_search_quality_evaluation.shared.utils import normalize_discovered_field_values
+
+
+def test_normalize__drops_none():
+    assert normalize_discovered_field_values([None]) == []
+
+
+def test_normalize__drops_empty_and_whitespace_only():
+    assert normalize_discovered_field_values(["", "  "]) == []
+
+
+def test_normalize__strips_surrounding_whitespace():
+    assert normalize_discovered_field_values(["  comedy ", "action"]) == ["comedy", "action"]
+
+
+def test_normalize__coerces_int_float_bool_to_str():
+    assert normalize_discovered_field_values([123, 4.5, True]) == ["123", "4.5", "True"]
+
+
+def test_normalize__rejects_dict_with_value_error():
+    with pytest.raises(ValueError):
+        normalize_discovered_field_values([{"a": 1}])
+
+
+def test_normalize__rejects_list_with_value_error():
+    with pytest.raises(ValueError):
+        normalize_discovered_field_values([["nested"]])
+
+
+def test_normalize__preserves_input_order():
+    # No sort, no dedupe — DataStore.add_query handles cleaned-text dedupe.
+    assert normalize_discovered_field_values(["b", "a", "b"]) == ["b", "a", "b"]

--- a/tests/llm_search_quality_evaluation/shared/test_query_source.py
+++ b/tests/llm_search_quality_evaluation/shared/test_query_source.py
@@ -1,0 +1,87 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from llm_search_quality_evaluation.shared.data_store import DataStore
+from llm_search_quality_evaluation.shared.models import Query
+
+
+@pytest.fixture
+def tmp_db_path(tmp_path: Path) -> Path:
+    return tmp_path / "datastore.json"
+
+
+@pytest.fixture
+def ds(tmp_db_path: Path) -> DataStore:
+    return DataStore(path=tmp_db_path, ignore_saved_data=True)
+
+
+def test_add_query__default_source_is_cached(ds):
+    q = ds.add_query("hello world")
+    assert q.source == "cached"
+
+
+def test_add_query__explicit_source_is_set(ds):
+    q = ds.add_query("hello world", source="user")
+    assert q.source == "user"
+
+
+def test_add_query__promotes_cached_to_user(ds):
+    """Re-asserting a previously-cached query as user-supplied promotes its label."""
+    q1 = ds.add_query("comedy movies")  # default cached
+    assert q1.source == "cached"
+
+    q2 = ds.add_query("comedy movies", source="user")
+    assert q2 is q1  # dedup hit
+    assert q1.source == "user"
+
+
+def test_add_query__promotes_llm_to_category(ds):
+    q = ds.add_query("comedy movies", source="llm")
+    assert q.source == "llm"
+    ds.add_query("comedy movies", source="category")
+    assert q.source == "category"
+
+
+def test_add_query__does_not_demote_user_to_llm(ds):
+    """A user-asserted query must not be downgraded by a later LLM-gen with the same text."""
+    q = ds.add_query("comedy movies", source="user")
+    ds.add_query("comedy movies", source="llm")
+    assert q.source == "user"
+
+
+def test_add_query__does_not_demote_category_to_cached(ds):
+    q = ds.add_query("comedy movies", source="category")
+    ds.add_query("comedy movies")  # no source -> no-op on existing
+    assert q.source == "category"
+
+
+def test_query_source_not_persisted(tmp_path: Path):
+    """The source label is a runtime concern: it must not be written to the JSON cache."""
+    db_path = tmp_path / "datastore.json"
+    ds = DataStore(path=db_path, ignore_saved_data=True)
+    ds.add_query("comedy movies", source="user")
+    ds.save()
+
+    raw = json.loads(db_path.read_text(encoding="utf-8"))
+    assert raw["queries"]
+    assert all("source" not in entry for entry in raw["queries"])
+
+
+def test_query_source_resets_to_cached_on_load(tmp_path: Path):
+    """A user/category-labeled query saved in run 1 should load as 'cached' in run 2."""
+    db_path = tmp_path / "datastore.json"
+    ds = DataStore(path=db_path, ignore_saved_data=True)
+    ds.add_query("comedy movies", source="user")
+    ds.save()
+
+    reloaded = DataStore(path=db_path, ignore_saved_data=False)
+    qs = reloaded.get_queries()
+    assert len(qs) == 1
+    assert qs[0].source == "cached"
+
+
+def test_query_model__source_default():
+    q = Query(text="hi")
+    assert q.source == "cached"

--- a/tests/llm_search_quality_evaluation/test_value_discovery_sample_templates.py
+++ b/tests/llm_search_quality_evaluation/test_value_discovery_sample_templates.py
@@ -1,0 +1,73 @@
+"""Regression test: shipped value-discovery sample templates must be parseable by the engines
+that load them. Catches the comment-in-JSON foot-gun (and would catch a `#` header sneaking
+into the YQL sample).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import requests
+
+from llm_search_quality_evaluation.shared.search_engines import SolrSearchEngine
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+TEMPLATES_DIR = REPO_ROOT / "examples" / "templates"
+
+
+def test_genre_facet_solr_json__parses_via_engine_loader():
+    """Solr engine `_parse_query_template` is `json.load` under the hood — comments would break it."""
+    template = TEMPLATES_DIR / "genre_facet_solr.json"
+
+    class _Resp:
+        def json(self):
+            return {"uniqueKey": "id"}
+        def raise_for_status(self):
+            pass
+
+    # Solr engine `__init__` issues a GET to fetch the unique key. Skip it.
+    orig_get = requests.get
+    try:
+        requests.get = lambda *a, **kw: _Resp()  # type: ignore[assignment]
+        engine = SolrSearchEngine("http://fake-solr/collection/")
+    finally:
+        requests.get = orig_get
+
+    payload = engine._parse_query_template(template)
+    assert isinstance(payload, dict)
+    assert payload["facet.field"] == "genres"
+    assert "facet.limit" in payload
+    # Solr params must be scalars (str/int/bool) — `requests.get(..., params=)` requires it.
+    for k, v in payload.items():
+        assert isinstance(v, (str, int, float, bool)), f"Solr param {k!r} must be a scalar, got {type(v).__name__}"
+
+
+def test_genre_facet_es_json__parses_via_json_load_with_aggs_shape():
+    template = TEMPLATES_DIR / "genre_facet_es.json"
+    payload = json.loads(template.read_text(encoding="utf-8"))
+    # Request body shape: `aggs` (not `aggregations` — that's the response key).
+    assert "aggs" in payload
+    # Convention: agg result key equals the field we'll be querying on.
+    assert "genres" in payload["aggs"]
+    assert "terms" in payload["aggs"]["genres"]
+    assert "field" in payload["aggs"]["genres"]["terms"]
+
+
+def test_genre_facet_opensearch_json__same_shape_as_es():
+    template = TEMPLATES_DIR / "genre_facet_opensearch.json"
+    payload = json.loads(template.read_text(encoding="utf-8"))
+    assert "aggs" in payload
+    assert "genres" in payload["aggs"]
+    assert "terms" in payload["aggs"]["genres"]
+    assert "field" in payload["aggs"]["genres"]["terms"]
+
+
+def test_genre_facet_vespa_yql__plain_text_no_hash_comments():
+    """The YQL sample is sent to Vespa verbatim. A `#` line would be parsed as part of the
+    query (or rejected). Disallow them in the shipped file."""
+    text = (TEMPLATES_DIR / "genre_facet_vespa.yql").read_text(encoding="utf-8")
+    assert "group(genres)" in text
+    for ln in text.splitlines():
+        assert not ln.lstrip().startswith("#"), f"YQL sample must not contain # lines: {ln!r}"
+        assert not ln.lstrip().startswith("//"), f"YQL sample must not contain // lines: {ln!r}"


### PR DESCRIPTION
This is a port of https://github.com/SeaseLtd/rated-ranking-evaluator/pull/266, which in itself is an accumulation of 3 PRs. So it's quite huge (description below), but I'm up for clarifying anything. @dantuzi - feel free to poke me on any common Slack channel and we can do a sync-type of work, if you think that helps!

# Changes summary

- **Micro-batching of LLM scoring** (`llm_micro_batch_size`, default `1`): score N docs for a
  query in one LLM call instead of N. The batch prompt is configurable
  (`llm_batch_score_prompt`) and validated at config load; retries on a per-batch budget
  (`llm_batch_max_retries`) cover provider errors and missing/unknown/duplicate `doc_id`
  responses, raising `BatchScoringError` on exhaustion.
- **Multithreading** (`llm_max_workers`, default `1`): optionally parallelize (a) query
  generation from seed docs and (b) relevance scoring (both the cartesian and top-K paths)
  via a `ThreadPoolExecutor`.
- **Category / facet queries** (`category_queries`): derive queries from the distinct values
  of a field — either explicit `values` or values discovered from an engine-native
  facet/aggregation/grouping template (`values_query_template_file`), optionally wrapped by a
  natural-language template (`query_text_template_file`). Adds a `query_sources` package and a
  per-engine `fetch_field_values` implementation (Solr facet, ES/OpenSearch terms agg, Vespa
  grouping).
- **Query source priority + per-run budget**: every query carries a `source`
  (`user` / `category` / `llm` / `cached`); when more queries exist than `num_queries_needed`,
  fresh sources this run are selected over cached ones
  (priority `user` = `category` < `llm` < `cached`, stable within a tier).
- **Durability**: `main()` wraps the work phase so a mid-run failure still saves in-memory
  progress to the datastore cache; a re-run picks up where it stopped.

## Behavioral changes to be aware of

These ship inside files that are otherwise textually identical to the #266 base after the
import remap — i.e. they are #266's own behavior, surfaced here for review:

- **`Query.source` is never persisted** (`Field(default="cached", exclude=True)`): every query
  loaded from the datastore JSON cache returns as `source="cached"`. A fresh `add_query(...)`
  this run *promotes* a deduped query to a higher-priority source. This is the backbone of the
  per-run query budget.
- **`DataStore` is now thread-safe** via a single `threading.RLock` (`RLock` because
  `create_rating_score` re-enters). Autosave captures a snapshot under the lock and writes it
  after releasing it, so under concurrent autosave on-disk progress is **not strictly
  monotonic** — an older snapshot can land last. This is intentional: the final `save()` is
  authoritative; autosave is a partial-progress convenience.
- **Vespa schema now defaults to `collection_name`** when `vespa_schema` is omitted, so a
  `search_engine_type: vespa` config can run without an explicit `vespa_schema`.
- **`BaseSearchEngine` gains an abstract `fetch_field_values(...)`**: any future
  `BaseSearchEngine` subclass must implement it (even if just `raise NotImplementedError` when
  value discovery is unsupported). The four concrete engines all implement it here.